### PR TITLE
Updated lib.rs > semver() with matching lightwight tags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,7 +245,7 @@ fn gen_semver_fn() -> String {
     semver_fn.push_str("    \"");
 
     let mut branch_cmd = Command::new("git");
-    branch_cmd.args(&["describe"]);
+    branch_cmd.args(&["describe", "--tags"]);
 
     if let Ok(o) = branch_cmd.output() {
         let po = String::from_utf8_lossy(&o.stdout[..]);


### PR DESCRIPTION
Can we enable matching a lightweight tag?

https://git-scm.com/docs/git-describe#git-describe---tags

Thanks in advance.