### PR TITLE
Update doc example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@
 //! #..
 //!
 //! [build-dependencies]
-//! vergen = "2"
+//! vergen = "3"
 //! ```
 //!
 //! ### Example 'build.rs'
@@ -68,7 +68,7 @@
 //!     flags.toggle(ConstantsFlags::SEMVER_FROM_CARGO_PKG);
 //!
 //!     // Generate the 'cargo:' key output
-//!     generate_cargo_keys(ConstantsFlags::all()).expect("Unable to generate the cargo keys!");
+//!     generate_cargo_keys(flags).expect("Unable to generate the cargo keys!");
 //! }
 //! ```
 //!


### PR DESCRIPTION
Update the crate version in the example.

Use `flags` variable that is created. Otherwise this variable is useless and produce a compiler warning.