### PR TITLE
Replace `failure` with boxed `std::error::Error`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ version = "3.0.4"
 [dependencies]
 bitflags = "1"
 chrono = "0"
-failure = "0"
 
 [dev-dependencies]
 lazy_static = "1"

--- a/src/output/codegen.rs
+++ b/src/output/codegen.rs
@@ -10,13 +10,14 @@
 //! the `include!` macro within your project.
 use crate::constants::{ConstantsFlags, CONST_PREFIX, CONST_TYPE};
 use crate::output::generate_build_info;
-use failure::Error;
 use std::env;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 
-fn gen_const<W: Write>(f: &mut W, comment: &str, name: &str, value: &str) -> Result<(), Error> {
+use super::Result;
+
+fn gen_const<W: Write>(f: &mut W, comment: &str, name: &str, value: &str) -> Result<()> {
     writeln!(
         f,
         "{}\n{}{}{}\"{}\";",
@@ -77,7 +78,7 @@ fn gen_const<W: Write>(f: &mut W, comment: &str, name: &str, value: &str) -> Res
 /// format!("{} {} blah {}", VERGEN_BUILD_TIMESTAMP, VERGEN_SHA, VERGEN_SEMVER)
 /// ```
 #[deprecated(since = "2.0.0", note = "Please use `generate_cargo_keys` instead")]
-pub fn generate_version_rs(flags: ConstantsFlags) -> Result<(), Error> {
+pub fn generate_version_rs(flags: ConstantsFlags) -> Result<()> {
     let dst = PathBuf::from(env::var("OUT_DIR")?);
     let mut f = File::create(&dst.join("version.rs"))?;
     let build_info = generate_build_info(flags)?;

--- a/src/output/envvar.rs
+++ b/src/output/envvar.rs
@@ -9,10 +9,11 @@
 //! Build time information.
 use crate::constants::ConstantsFlags;
 use crate::output::generate_build_info;
-use failure::Fallible;
 use std::fs::{self, File};
 use std::io::Read;
 use std::path::PathBuf;
+
+use super::Result;
 
 /// Generate the `cargo:` key output
 ///
@@ -32,7 +33,7 @@ use std::path::PathBuf;
 ///     generate_cargo_keys(ConstantsFlags::all()).expect("Unable to generate cargo keys!");
 /// }
 /// ```
-pub fn generate_cargo_keys(flags: ConstantsFlags) -> Fallible<()> {
+pub fn generate_cargo_keys(flags: ConstantsFlags) -> Result<()> {
     // Generate the build info map.
     let build_info = generate_build_info(flags)?;
 
@@ -95,9 +96,7 @@ pub fn generate_cargo_keys(flags: ConstantsFlags) -> Fallible<()> {
                 eprintln!("You are most likely in a detached HEAD state");
             }
         } else {
-            return Err(failure::err_msg(
-                "Invalid .git format (Not a directory or a file)",
-            ));
+            return Err("Invalid .git format (Not a directory or a file)".into());
         };
     } else {
         eprintln!("Unable to generate 'cargo:rerun-if-changed'");

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -9,7 +9,6 @@
 //! Output types
 use crate::constants::*;
 use chrono::Utc;
-use failure::Fallible;
 use std::collections::HashMap;
 use std::env;
 use std::process::Command;
@@ -17,7 +16,9 @@ use std::process::Command;
 pub mod codegen;
 pub mod envvar;
 
-pub fn generate_build_info(flags: ConstantsFlags) -> Fallible<HashMap<VergenKey, String>> {
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+pub fn generate_build_info(flags: ConstantsFlags) -> Result<HashMap<VergenKey, String>> {
     let mut build_info = HashMap::new();
     let now = Utc::now();
 


### PR DESCRIPTION
The `failure` crate is kinda deprecated and superseded by many other crates.
And boxed `std::error::Error` is feasible for vergen.

On a side note `failure_derive` breaks the build of many crates because of the use of a "private" type in `quote`.
https://users.rust-lang.org/t/failure-derive-compilation-error/39062