### PR TITLE
Add compiler version information

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ version = "3.1.0"
 [dependencies]
 bitflags = "1"
 chrono = "0"
+rustc_version = "0"
 
 [dev-dependencies]
 lazy_static = "1"

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ VERGEN_COMMIT_DATE        |2018-08-08
 VERGEN_TARGET_TRIPLE      |x86_64-unknown-linux-gnu
 VERGEN_SEMVER             |v3.0.0
 VERGEN_SEMVER_LIGHTWEIGHT |v3.0.0
+VERGEN_RUSTC_SEMVER       |1.4.3
+VERGEN_RUSTC_CHANNEL      |stable
+VERGEN_HOST_TRIPLE        |x86_64-unknown-linux-gnu
 
 The variable generation can be toggled on or off at an individual level
 via [ConstantsFlags](crate::constants::ConstantsFlags)

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -29,7 +29,10 @@ bitflags!(
     ///     ConstantsFlags::SHA |
     ///     ConstantsFlags::COMMIT_DATE |
     ///     ConstantsFlags::TARGET_TRIPLE |
+    ///     ConstantsFlags::HOST_TRIPLE |
     ///     ConstantsFlags::SEMVER |
+    ///     ConstantsFlags::RUSTC_SEMVER |
+    ///     ConstantsFlags::RUSTC_CHANNEL |
     ///     ConstantsFlags::REBUILD_ON_HEAD_CHANGE;
     ///
     /// assert_eq!(actual_flags, expected_flags)
@@ -39,49 +42,61 @@ bitflags!(
         /// Generate the build timestamp constant.
         ///
         /// `2018-08-09T15:15:57.282334589+00:00`
-        const BUILD_TIMESTAMP        = 0b0000_0000_0001;
+        const BUILD_TIMESTAMP        = 0b0000_0000_0000_0001;
         /// Generate the build date constant.
         ///
         /// `2018-08-09`
-        const BUILD_DATE             = 0b0000_0000_0010;
+        const BUILD_DATE             = 0b0000_0000_0000_0010;
         /// Generate the SHA constant.
         ///
         /// `75b390dc6c05a6a4aa2791cc7b3934591803bc22`
-        const SHA                    = 0b0000_0000_0100;
+        const SHA                    = 0b0000_0000_0000_0100;
         /// Generate the short SHA constant.
         ///
         /// `75b390d`
-        const SHA_SHORT              = 0b0000_0000_1000;
+        const SHA_SHORT              = 0b0000_0000_0000_1000;
         /// Generate the commit date constant.
         ///
         /// `2018-08-08`
-        const COMMIT_DATE            = 0b0000_0001_0000;
+        const COMMIT_DATE            = 0b0000_0000_0001_0000;
         /// Generate the target triple constant.
         ///
         /// `x86_64-unknown-linux-gnu`
-        const TARGET_TRIPLE          = 0b0000_0010_0000;
+        const TARGET_TRIPLE          = 0b0000_0000_0010_0000;
         /// Generate the semver constant.
         ///
         /// This defaults to the output of `git describe`.  If that output is
         /// empty, the the `CARGO_PKG_VERSION` environment variable is used.
         ///
         /// `v0.1.0`
-        const SEMVER                 = 0b0000_0100_0000;
+        const SEMVER                 = 0b0000_0000_0100_0000;
         /// Generate the semver constant, including lightweight tags.
         ///
         /// This defaults to the output of `git describe --tags`.  If that output
         /// is empty, the the `CARGO_PKG_VERSION` environment variable is used.
         ///
         /// `v0.1.0`
-        const SEMVER_LIGHTWEIGHT     = 0b0000_1000_0000;
+        const SEMVER_LIGHTWEIGHT     = 0b0000_0000_1000_0000;
         /// Generate the `cargo:rebuild-if-changed=.git/HEAD` and the
         /// `cargo:rebuild-if-changed=.git/<ref>` cargo build output.
-        const REBUILD_ON_HEAD_CHANGE = 0b0001_0000_0000;
+        const REBUILD_ON_HEAD_CHANGE = 0b0000_0001_0000_0000;
         /// Generate the semver constant from `CARGO_PKG_VERSION`.  This is
         /// mutually exclusive with the `SEMVER` flag.
         ///
         /// `0.1.0`
-        const SEMVER_FROM_CARGO_PKG  = 0b0010_0000_0000;
+        const SEMVER_FROM_CARGO_PKG  = 0b0000_0010_0000_0000;
+        /// Generates the rustc compiler version.
+        ///
+        /// `1.43.1`
+        const RUSTC_SEMVER           = 0b0000_0100_0000_0000;
+        /// Generates the channel the rust compiler is installed from.
+        ///
+        /// `nightly`
+        const RUSTC_CHANNEL          = 0b0000_1000_0000_0000;
+        /// Generate the host triple constant.
+        ///
+        /// `x86_64-unknown-linux-gnu`
+        const HOST_TRIPLE            = 0b0001_0000_0000_0000;
     }
 );
 
@@ -106,6 +121,12 @@ pub const SEMVER_NAME: &str = "VERGEN_SEMVER";
 pub const SEMVER_COMMENT: &str = "/// Semver";
 pub const SEMVER_TAGS_NAME: &str = "VERGEN_SEMVER_LIGHTWEIGHT";
 pub const SEMVER_TAGS_COMMENT: &str = "/// Semver (Lightweight)";
+pub const RUSTC_SEMVER_NAME: &str = "VERGEN_RUSTC_SEMVER";
+pub const RUSTC_SEMVER_COMMENT: &str = "/// Rustc Version";
+pub const RUSTC_CHANNEL_NAME: &str = "VERGEN_RUSTC_CHANNEL";
+pub const RUSTC_CHANNEL_COMMENT: &str = "/// Rustc Release Channel";
+pub const HOST_TRIPLE_NAME: &str = "VERGEN_HOST_TRIPLE";
+pub const HOST_TRIPLE_COMMENT: &str = "/// Host Triple";
 
 #[cfg(test)]
 mod test {
@@ -129,6 +150,9 @@ mod test {
             ConstantsFlags::SEMVER_FROM_CARGO_PKG.bits(),
             0b0010_0000_0000
         );
+        assert_eq!(ConstantsFlags::RUSTC_SEMVER.bits(), 0b0100_0000_0000);
+        assert_eq!(ConstantsFlags::RUSTC_CHANNEL.bits(), 0b1000_0000_0000);
+        assert_eq!(ConstantsFlags::HOST_TRIPLE.bits(), 0b0001_0000_0000_0000);
     }
 
     #[test]
@@ -151,5 +175,11 @@ mod test {
         assert_eq!(SEMVER_COMMENT, "/// Semver");
         assert_eq!(SEMVER_TAGS_NAME, "VERGEN_SEMVER_LIGHTWEIGHT");
         assert_eq!(SEMVER_TAGS_COMMENT, "/// Semver (Lightweight)");
+        assert_eq!(RUSTC_SEMVER_NAME, "VERGEN_RUSTC_SEMVER");
+        assert_eq!(RUSTC_SEMVER_COMMENT, "/// Rustc Version");
+        assert_eq!(RUSTC_CHANNEL_NAME, "VERGEN_RUSTC_CHANNEL");
+        assert_eq!(RUSTC_CHANNEL_COMMENT, "/// Rustc Release Channel");
+        assert_eq!(HOST_TRIPLE_NAME, "VERGEN_HOST_TRIPLE");
+        assert_eq!(HOST_TRIPLE_COMMENT, "/// Host Triple");
     }
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -9,6 +9,7 @@
 //! Output types
 use crate::constants::*;
 use chrono::Utc;
+use rustc_version::Channel;
 use std::collections::HashMap;
 use std::env;
 use std::process::Command;
@@ -82,6 +83,29 @@ pub fn generate_build_info(flags: ConstantsFlags) -> Result<HashMap<VergenKey, S
         build_info.insert(VergenKey::SemverLightweight, semver);
     }
 
+    if flags.intersects(ConstantsFlags::RUSTC_SEMVER | ConstantsFlags::RUSTC_CHANNEL | ConstantsFlags::HOST_TRIPLE) {
+    let rustc = rustc_version::version_meta().unwrap();
+
+        if flags.contains(ConstantsFlags::RUSTC_SEMVER) {
+            build_info.insert(VergenKey::RustcSemver, format!("{}", rustc.semver));
+        }
+
+        if flags.contains(ConstantsFlags::RUSTC_CHANNEL) {
+            let channel = match rustc.channel {
+                Channel::Dev => "dev",
+                Channel::Nightly => "nightly",
+                Channel::Beta => "beta",
+                Channel::Stable => "stable",
+            }.to_string();
+
+            build_info.insert(VergenKey::RustcChannel, channel);
+        }
+
+        if flags.contains(ConstantsFlags::HOST_TRIPLE) {
+            build_info.insert(VergenKey::HostTriple, rustc.host);
+        }
+    }
+
     Ok(build_info)
 }
 
@@ -114,6 +138,12 @@ pub enum VergenKey {
     /// The semver version from the last git tag, including lightweight.
     /// (VERGEN_SEMVER_LIGHTWEIGHT)
     SemverLightweight,
+    /// The version information of the rust compiler. (VERGEN_RUSTC_SEMVER)
+    RustcSemver,
+    /// The release channel of the rust compiler. (VERGEN_RUSTC_CHANNEL)
+    RustcChannel,
+    /// The host triple. (VERGEN_HOST_TRIPLE)
+    HostTriple,
 }
 
 impl VergenKey {
@@ -128,6 +158,9 @@ impl VergenKey {
             VergenKey::TargetTriple => TARGET_TRIPLE_COMMENT,
             VergenKey::Semver => SEMVER_COMMENT,
             VergenKey::SemverLightweight => SEMVER_TAGS_COMMENT,
+            VergenKey::RustcSemver => RUSTC_SEMVER_COMMENT,
+            VergenKey::RustcChannel => RUSTC_CHANNEL_COMMENT,
+            VergenKey::HostTriple => HOST_TRIPLE_COMMENT,
         }
     }
 
@@ -142,6 +175,9 @@ impl VergenKey {
             VergenKey::TargetTriple => TARGET_TRIPLE_NAME,
             VergenKey::Semver => SEMVER_NAME,
             VergenKey::SemverLightweight => SEMVER_TAGS_NAME,
+            VergenKey::RustcSemver => RUSTC_SEMVER_NAME,
+            VergenKey::RustcChannel => RUSTC_CHANNEL_NAME,
+            VergenKey::HostTriple => HOST_TRIPLE_NAME,
         }
     }
 }


### PR DESCRIPTION
This PR adds compiler version information courtesy of [`rustc_version`](https://crates.io/crates/rustc_version).

For example, this makes the following possible:

```
/// Application version string. Sample:
///
/// application 0.0.1
///
/// Built from commit 9510c567d23dd80c4b0d44ff6e63d332868c2de1 at 2020-05-09T18:29:10.402031601+00:00 with rustc 1.43.1 stable for x86_64-unknown-linux-gnu on x86_64-unknown-linux-gnu.
let version = concat!(
	env!("VERGEN_SEMVER"), "\n\nBuilt from commit ", env!("VERGEN_SHA"), " at ", env!("VERGEN_BUILD_TIMESTAMP"),
	" with rustc ", env!("VERGEN_RUSTC_SEMVER"), " ", env!("VERGEN_RUSTC_CHANNEL"), " for ", env!("VERGEN_TARGET_TRIPLE"),
	" on ", env!("VERGEN_HOST_TRIPLE"), "."),
```