### PR TITLE
Added support for 'TAG_DIRTY' flag, to add '-dirty' to the SHA variables

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -36,7 +36,8 @@ bitflags!(
     ///     ConstantsFlags::RUSTC_SEMVER |
     ///     ConstantsFlags::RUSTC_CHANNEL |
     ///     ConstantsFlags::REBUILD_ON_HEAD_CHANGE |
-    ///     ConstantsFlags::BRANCH;
+    ///     ConstantsFlags::BRANCH |
+    ///     ConstantsFlags::TAG_DIRTY;
     ///
     /// assert_eq!(actual_flags, expected_flags)
     /// # }
@@ -104,6 +105,10 @@ bitflags!(
         ///
         /// `master`
         const BRANCH                 = 0b0010_0000_0000_0000;
+        /// Include 'dirty' indicator on the SHAs when built on directory with changes
+        ///
+        /// `75b390d-dirty`
+        const TAG_DIRTY              = 0b0100_0000_0000_0000;
     }
 );
 
@@ -163,6 +168,7 @@ mod test {
         assert_eq!(ConstantsFlags::RUSTC_CHANNEL.bits(), 0b1000_0000_0000);
         assert_eq!(ConstantsFlags::HOST_TRIPLE.bits(), 0b0001_0000_0000_0000);
         assert_eq!(ConstantsFlags::BRANCH.bits(), 0b0010_0000_0000_0000);
+        assert_eq!(ConstantsFlags::TAG_DIRTY.bits(), 0b0100_0000_0000_0000);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,9 @@
 //! If you wish to force `CARGO_PKG_VERSION`, toggle off `SEMVER` and toggle
 //! on `SEMVER_FROM_CARGO_PKG`.
 //!
+//! `VERGEN_SEMVER` will also include a dirty tag if the build happend in a directory with
+//! changes, i.e. `75b390d-dirty`.  This behavior can be toggled off via `TAG_DIRTY`.
+//!
 //! # Re-build On Changed HEAD
 //! `vergen` can also be configured to re-run `build.rs` when either `.git/HEAD` or
 //! the file that `.git/HEAD` points at changes.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,25 +65,36 @@
 //!
 //! ### Example 'build.rs'
 //! ```
-//! extern crate vergen;
-//!
-//! use vergen::{ConstantsFlags, generate_cargo_keys};
-//!
-//! fn main() {
+//! # use vergen::{ConstantsFlags, generate_cargo_keys};
+//! #
+//! # fn main() {
 //!     // Setup the flags, toggling off the 'SEMVER_FROM_CARGO_PKG' flag
 //!     let mut flags = ConstantsFlags::all();
 //!     flags.toggle(ConstantsFlags::SEMVER_FROM_CARGO_PKG);
 //!
 //!     // Generate the 'cargo:' key output
 //!     generate_cargo_keys(flags).expect("Unable to generate the cargo keys!");
-//! }
+//! # }
+//! ```
+//! ### Example 'build.rs' with SEMVER from CARGO_PKG_VERSION
+//! ```
+//! # use vergen::{ConstantsFlags, generate_cargo_keys};
+//! #
+//! # fn other() {
+//!     // Setup the flags, toggling off the 'SEMVER' flag to use `CARGO_PKG_VERSION`
+//!     let mut flags = ConstantsFlags::all();
+//!     flags.toggle(ConstantsFlags::SEMVER);
+//!
+//!     // Generate the 'cargo:' key output
+//!     generate_cargo_keys(flags).expect("Unable to generate the cargo keys!");
+//! # }
 //! ```
 //!
 //! ### Use the constants in your code
 //! ```
-//! fn my_fn() {
+//! # fn my_fn() {
 //!     println!("Build Timestamp: {}", env!("VERGEN_BUILD_TIMESTAMP"));
-//! }
+//! # }
 //! ```
 //!
 //! ## **DEPRECATED** - `version.rs` File Build Script Output

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -39,12 +39,14 @@ pub(crate) fn generate_build_info(flags: ConstantsFlags) -> Result<HashMap<Verge
     }
 
     if flags.contains(ConstantsFlags::SHA) {
-        let sha = run_command(Command::new("git").args(&["rev-parse", "HEAD"]));
+        let mut sha = run_command(Command::new("git").args(&["rev-parse", "HEAD"]));
+        tag_dirty(&mut sha, &flags);
         let _ = build_info.insert(VergenKey::Sha, sha);
     }
 
     if flags.contains(ConstantsFlags::SHA_SHORT) {
-        let sha = run_command(Command::new("git").args(&["rev-parse", "--short", "HEAD"]));
+        let mut sha = run_command(Command::new("git").args(&["rev-parse", "--short", "HEAD"]));
+        tag_dirty(&mut sha, &flags);
         let _ = build_info.insert(VergenKey::ShortSha, sha);
     }
 
@@ -122,6 +124,15 @@ pub(crate) fn generate_build_info(flags: ConstantsFlags) -> Result<HashMap<Verge
     }
 
     Ok(build_info)
+}
+
+fn tag_dirty(sha: &mut String, flags: &ConstantsFlags) {
+    if flags.contains(ConstantsFlags::TAG_DIRTY) {
+        let diff = run_command(Command::new("git").args(&["diff"]));
+        if !diff.is_empty() {
+            sha.push_str("-dirty");
+        }
+    }
 }
 
 fn run_command(command: &mut Command) -> String {

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -213,4 +213,12 @@ impl VergenKey {
 }
 
 #[cfg(test)]
-mod test {}
+mod test {
+    use super::run_command;
+    use std::process::Command;
+
+    #[test]
+    fn bad_command_generates_unknown() {
+        assert_eq!(run_command(&mut Command::new("zzzyyyxxx")), "UNKNOWN");
+    }
+}


### PR DESCRIPTION
By default, '-dirty' will be added the the SHA and SHORT_SHA environment variables if the build has run on a directory with uncommitted changes.   This behavior can be toggle off via the `TAG_DIRTY` flag.

Fixes #25 