### PR TITLE
Added command to determine properly the git base directory

### DIFF
--- a/src/output/envvar.rs
+++ b/src/output/envvar.rs
@@ -11,7 +11,7 @@ use crate::constants::ConstantsFlags;
 use crate::output::generate_build_info;
 use std::fs::{self, File};
 use std::io::Read;
-use std::path::PathBuf;
+use std::{path::PathBuf, process::Command};
 
 use super::Result;
 
@@ -46,7 +46,10 @@ pub fn generate_cargo_keys(flags: ConstantsFlags) -> Result<()> {
         println!("cargo:rustc-env={}={}", k.name(), v);
     }
 
-    let git_dir_or_file = PathBuf::from(".git");
+    let base = super::run_command(Command::new("git").args(&["rev-parse", "--show-toplevel"]));
+    let mut git_dir_or_file = PathBuf::from(base);
+    git_dir_or_file.push(".git");
+
     if let Ok(metadata) = fs::metadata(&git_dir_or_file) {
         if metadata.is_dir() {
             // Echo the HEAD path

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -17,9 +17,7 @@ use crate::constants::{
 };
 use chrono::Utc;
 use rustc_version::Channel;
-use std::collections::HashMap;
-use std::env;
-use std::process::Command;
+use std::{collections::HashMap, env, process::Command};
 
 pub(crate) mod codegen;
 pub(crate) mod envvar;
@@ -124,7 +122,7 @@ pub(crate) fn generate_build_info(flags: ConstantsFlags) -> Result<HashMap<Verge
     Ok(build_info)
 }
 
-fn run_command(command: &mut Command) -> String {
+pub(crate) fn run_command(command: &mut Command) -> String {
     if let Ok(o) = command.output() {
         if o.status.success() {
             return String::from_utf8_lossy(&o.stdout).trim().to_owned();


### PR DESCRIPTION
Added command to properly determine the base git directory to be used within `generate_cargo_keys`.

Fixes #21 