### PR TITLE
git2: Disable default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ bitflags = "1"
 chrono = { version = "0", optional = true }
 enum-iterator = "0"
 getset = "0"
-git2 = { version = "0", optional = true }
+git2 = { version = "0", optional = true, default-features = false }
 rustc_version = { version = "0", optional = true }
 serde = "1"
 serde_derive = "1"


### PR DESCRIPTION
This fixes #36 by disabling the `git2` features that rely on `openssl-sys`, since it looks like we're not actually using any of them in this crate :)