### PR TITLE
Enable CI for pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-on: [push]
+on: [push, pull_request]
 
 name: CI
 


### PR DESCRIPTION
In #37 it looked like GitHub Actions is currently not running for pull requests. This PR fixes the problem by slightly adjusting the workflow config.