### PR TITLE
v4.0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 name = "vergen"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "4.0.1"
+version = "4.0.2"
 
 [features]
 default = ["build", "git", "rustc"]


### PR DESCRIPTION
* Minor release so `git2` default features are turned off to minimize transitive dependencies (specifically `openssl-sys`)