### PR TITLE
fix: Require rustc_version ^0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ chrono = { version = "0", optional = true }
 enum-iterator = "0"
 getset = "0"
 git2 = { version = "0", optional = true, default-features = false }
-rustc_version = { version = "0", optional = true }
+rustc_version = { version = "0.3.1", optional = true }
 serde = "1"
 serde_derive = "1"
 


### PR DESCRIPTION
### Description

Requires `rustc_version` to be at least 0.3.1 in order to prevent the following error if another dependency uses an older version of `rustc_version`.  The `llvm_version` field on `rustc_version::VersionMeta` was added in rustc_version `0.3.1`.

```
error[E0609]: no field `llvm_version` on type `VersionMeta`
  --> /home/drk/.cargo/registry/src/github.com-1ecc6299db9ec823/vergen-4.0.2/src/feature/rustc.rs:79:42
   |
79 |             if let Some(llvmver) = rustc.llvm_version {
   |                                          ^^^^^^^^^^^^ unknown field
   |
   = note: available fields are: `semver`, `commit_hash`, `commit_date`, `build_date`, `channel` ... and 2 others

error: aborting due to previous error

For more information about this error, try `rustc --explain E0609`.
error: could not compile `vergen`
```

### Tested

Following tests passes.

```bash
cargo fmt
cargo clippy --all
cargo build-all-features
cargo test-all-features
```
