### PR TITLE
Added a `cargo` feature to expose some cargo env variable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ chrono = "0"
 lazy_static = "1"
 regex = "1"
 rustversion = "1"
+serial_test = "0"
 
 [package.metadata.cargo-all-features]
 skip_optional_dependencies = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ serde_derive = "1"
 chrono = "0"
 
 [dev-dependencies]
-ctor = "0"
 lazy_static = "1"
 regex = "1"
 rustversion = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,9 @@ repository = "https://github.com/rustyhorde/vergen"
 version = "4.0.3"
 
 [features]
-default = ["build", "git", "rustc"]
+default = ["build", "cargo", "git", "rustc"]
 build = ["chrono"]
+cargo = []
 git = ["chrono", "git2"]
 rustc = ["rustc_version"]
 
@@ -32,6 +33,7 @@ serde_derive = "1"
 chrono = "0"
 
 [dev-dependencies]
+ctor = "0"
 lazy_static = "1"
 regex = "1"
 rustversion = "1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,13 +10,14 @@
 
 use crate::{
     constants::{
-        ConstantsFlags, BUILD_DATE_NAME, BUILD_TIMESTAMP_NAME, GIT_BRANCH_NAME,
-        GIT_COMMIT_DATE_NAME, GIT_SEMVER_NAME, GIT_SEMVER_TAGS_NAME, GIT_SHA_NAME,
-        GIT_SHA_SHORT_NAME, RUSTC_CHANNEL_NAME, RUSTC_COMMIT_DATE, RUSTC_COMMIT_HASH,
-        RUSTC_HOST_TRIPLE_NAME, RUSTC_LLVM_VERSION, RUSTC_SEMVER_NAME,
+        ConstantsFlags, BUILD_DATE_NAME, BUILD_TIMESTAMP_NAME, CARGO_FEATURES, CARGO_PROFILE,
+        CARGO_TARGET_TRIPLE, GIT_BRANCH_NAME, GIT_COMMIT_DATE_NAME, GIT_SEMVER_NAME,
+        GIT_SEMVER_TAGS_NAME, GIT_SHA_NAME, GIT_SHA_SHORT_NAME, RUSTC_CHANNEL_NAME,
+        RUSTC_COMMIT_DATE, RUSTC_COMMIT_HASH, RUSTC_HOST_TRIPLE_NAME, RUSTC_LLVM_VERSION,
+        RUSTC_SEMVER_NAME,
     },
     error::Result,
-    feature::{add_build_config, add_git_config, add_rustc_config},
+    feature::{add_build_config, add_cargo_config, add_git_config, add_rustc_config},
 };
 use enum_iterator::IntoEnumIterator;
 use getset::{Getters, MutGetters};
@@ -57,6 +58,12 @@ pub(crate) enum VergenKey {
     RustcLlvmVersion,
     /// The version information of the rust compiler. (VERGEN_RUSTC_SEMVER)
     RustcSemver,
+    /// The cargo target triple (VERGEN_CARGO_TARGET_TRIPLE)
+    CargoTargetTriple,
+    /// The cargo profile (VERGEN_CARGO_PROFILE)
+    CargoProfile,
+    /// The cargo features (VERGEN_CARGO_FEATURES)
+    CargoFeatures,
 }
 
 impl VergenKey {
@@ -77,6 +84,9 @@ impl VergenKey {
             VergenKey::RustcHostTriple => RUSTC_HOST_TRIPLE_NAME,
             VergenKey::RustcLlvmVersion => RUSTC_LLVM_VERSION,
             VergenKey::RustcSemver => RUSTC_SEMVER_NAME,
+            VergenKey::CargoTargetTriple => CARGO_TARGET_TRIPLE,
+            VergenKey::CargoProfile => CARGO_PROFILE,
+            VergenKey::CargoFeatures => CARGO_FEATURES,
         }
     }
 }
@@ -110,6 +120,7 @@ impl Config {
         add_build_config(flags, &mut config);
         add_git_config(flags, repo_path, &mut config)?;
         add_rustc_config(flags, &mut config)?;
+        add_cargo_config(flags, &mut config);
 
         Ok(config)
     }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -36,7 +36,10 @@ bitflags!(
     ///     ConstantsFlags::BRANCH |
     ///     ConstantsFlags::RUSTC_COMMIT_HASH |
     ///     ConstantsFlags::RUSTC_COMMIT_DATE |
-    ///     ConstantsFlags::RUSTC_LLVM_VERSION;
+    ///     ConstantsFlags::RUSTC_LLVM_VERSION |
+    ///     ConstantsFlags::CARGO_TARGET_TRIPLE |
+    ///     ConstantsFlags::CARGO_PROFILE |
+    ///     ConstantsFlags::CARGO_FEATURES;
     ///
     /// assert_eq!(actual_flags, expected_flags)
     /// # }
@@ -108,10 +111,22 @@ bitflags!(
         ///
         /// `01/22/21`
         const RUSTC_COMMIT_DATE      = 0b1000_0000_0000_0000;
-        // Generates the rustc LLVM version
+        /// Generates the rustc LLVM version
         ///
         /// `1.2.3`
         const RUSTC_LLVM_VERSION     = 0b0001_0000_0000_0000_0000;
+        /// Generates the cargo target triple constant.
+        ///
+        /// `x86_64-unknown-linux-gnu`
+        const CARGO_TARGET_TRIPLE    = 0b0010_0000_0000_0000_0000;
+        /// Generates the cargo profile constant.
+        ///
+        /// `debug`
+        const CARGO_PROFILE          = 0b0100_0000_0000_0000_0000;
+        /// Generates the cargo features constant.
+        ///
+        /// `git,cargo`
+        const CARGO_FEATURES         = 0b1000_0000_0000_0000_0000;
     }
 );
 
@@ -134,6 +149,11 @@ pub(crate) const RUSTC_SEMVER_NAME: &str = "VERGEN_RUSTC_SEMVER";
 pub(crate) const RUSTC_COMMIT_HASH: &str = "VERGEN_RUSTC_COMMIT_HASH";
 pub(crate) const RUSTC_COMMIT_DATE: &str = "VERGEN_RUSTC_COMMIT_DATE";
 pub(crate) const RUSTC_LLVM_VERSION: &str = "VERGEN_RUSTC_LLVM_VERSION";
+
+// cargo Constants
+pub(crate) const CARGO_TARGET_TRIPLE: &str = "VERGEN_CARGO_TARGET_TRIPLE";
+pub(crate) const CARGO_PROFILE: &str = "VERGEN_CARGO_PROFILE";
+pub(crate) const CARGO_FEATURES: &str = "VERGEN_CARGO_FEATURES";
 
 #[cfg(test)]
 mod test {
@@ -175,6 +195,18 @@ mod test {
             ConstantsFlags::RUSTC_LLVM_VERSION.bits(),
             0b0001_0000_0000_0000_0000
         );
+        assert_eq!(
+            ConstantsFlags::CARGO_TARGET_TRIPLE.bits(),
+            0b0010_0000_0000_0000_0000
+        );
+        assert_eq!(
+            ConstantsFlags::CARGO_PROFILE.bits(),
+            0b0100_0000_0000_0000_0000
+        );
+        assert_eq!(
+            ConstantsFlags::CARGO_FEATURES.bits(),
+            0b1000_0000_0000_0000_0000
+        );
     }
 
     #[test]
@@ -198,5 +230,10 @@ mod test {
         assert_eq!(RUSTC_COMMIT_HASH, "VERGEN_RUSTC_COMMIT_HASH");
         assert_eq!(RUSTC_COMMIT_DATE, "VERGEN_RUSTC_COMMIT_DATE");
         assert_eq!(RUSTC_LLVM_VERSION, "VERGEN_RUSTC_LLVM_VERSION");
+
+        // cargo Constants
+        assert_eq!(CARGO_TARGET_TRIPLE, "VERGEN_CARGO_TARGET_TRIPLE");
+        assert_eq!(CARGO_PROFILE, "VERGEN_CARGO_PROFILE");
+        assert_eq!(CARGO_FEATURES, "VERGEN_CARGO_FEATURES");
     }
 }

--- a/src/feature/cargo.rs
+++ b/src/feature/cargo.rs
@@ -111,6 +111,7 @@ mod test {
     }
 
     #[test]
+    #[serial_test::serial]
     fn add_cargo_config_works() {
         setup();
         let mut config = Config::default();
@@ -121,6 +122,7 @@ mod test {
     }
 
     #[test]
+    #[serial_test::serial]
     fn default_feature_works() {
         setup();
         env::remove_var("CARGO_FEATURE_GIT");

--- a/src/feature/cargo.rs
+++ b/src/feature/cargo.rs
@@ -1,0 +1,149 @@
+// Copyright (c) 2016, 2018, 2021 vergen developers
+//
+// Licensed under the Apache License, Version 2.0
+// <LICENSE-APACHE or http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+// license <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. All files in the project carrying such notice may not be copied,
+// modified, or distributed except according to those terms.
+
+//! `vergen` cargo feature
+
+use crate::{config::Config, constants::ConstantsFlags};
+#[cfg(feature = "cargo")]
+use {
+    crate::{config::VergenKey, feature::add_entry},
+    std::env,
+};
+
+#[cfg(feature = "cargo")]
+pub(crate) fn add_cargo_config(flags: ConstantsFlags, config: &mut Config) {
+    if flags.intersects(
+        ConstantsFlags::CARGO_TARGET_TRIPLE
+            | ConstantsFlags::CARGO_PROFILE
+            | ConstantsFlags::CARGO_FEATURES,
+    ) {
+        if flags.contains(ConstantsFlags::CARGO_TARGET_TRIPLE) {
+            add_entry(
+                config.cfg_map_mut(),
+                VergenKey::CargoTargetTriple,
+                env::var("TARGET").ok(),
+            );
+        }
+        if flags.contains(ConstantsFlags::CARGO_PROFILE) {
+            add_entry(
+                config.cfg_map_mut(),
+                VergenKey::CargoProfile,
+                env::var("PROFILE").ok(),
+            );
+        }
+        if flags.contains(ConstantsFlags::CARGO_FEATURES) {
+            let features: Vec<String> = env::vars().filter_map(is_cargo_feature).collect();
+            let feature_str = features.as_slice().join(",");
+            let value = if feature_str.is_empty() {
+                Some("default".to_string())
+            } else {
+                Some(feature_str)
+            };
+            add_entry(config.cfg_map_mut(), VergenKey::CargoFeatures, value);
+        }
+    }
+}
+
+#[cfg(feature = "cargo")]
+fn is_cargo_feature(var: (String, String)) -> Option<String> {
+    let (k, v) = var;
+    if k.starts_with("CARGO_FEATURE_") {
+        Some(v)
+    } else {
+        None
+    }
+}
+
+#[cfg(not(feature = "cargo"))]
+pub(crate) fn add_cargo_config(_flags: ConstantsFlags, _config: &mut Config) {}
+
+#[cfg(all(test, feature = "cargo"))]
+mod test {
+    use super::add_cargo_config;
+    use crate::{
+        config::{Config, VergenKey},
+        constants::ConstantsFlags,
+        test::get_map_value,
+    };
+    use std::{collections::BTreeMap, env};
+
+    fn check_cargo_instructions(cfg_map: &BTreeMap<VergenKey, Option<String>>) {
+        assert_eq!(
+            &get_map_value(VergenKey::CargoTargetTriple, cfg_map),
+            "x86_64-unknown-linux-gnu"
+        );
+        assert_eq!(&get_map_value(VergenKey::CargoProfile, cfg_map), "debug");
+    }
+
+    fn check_cargo_keys(cfg_map: &BTreeMap<VergenKey, Option<String>>) {
+        let mut count = 0;
+        for (k, v) in cfg_map {
+            match *k {
+                VergenKey::CargoTargetTriple
+                | VergenKey::CargoProfile
+                | VergenKey::CargoFeatures => {
+                    assert!(v.is_some());
+                    count += 1;
+                }
+                _ => {}
+            }
+        }
+        assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn add_cargo_config_works() {
+        let mut config = Config::default();
+        add_cargo_config(ConstantsFlags::all(), &mut config);
+        check_cargo_keys(config.cfg_map());
+        check_cargo_instructions(config.cfg_map());
+    }
+
+    #[test]
+    fn default_feature_works() {
+        env::remove_var("CARGO_FEATURE_GIT");
+        env::remove_var("CARGO_FEATURE_BUILD");
+        let mut config = Config::default();
+        add_cargo_config(ConstantsFlags::all(), &mut config);
+        check_cargo_keys(config.cfg_map());
+        check_cargo_instructions(config.cfg_map());
+        env::set_var("CARGO_FEATURE_GIT", "git");
+        env::set_var("CARGO_FEATURE_BUILD", "build");
+    }
+}
+
+#[cfg(all(test, not(feature = "cargo")))]
+mod test {
+    use super::add_cargo_config;
+    use crate::{
+        config::{Config, VergenKey},
+        constants::ConstantsFlags,
+    };
+    use std::collections::BTreeMap;
+
+    fn check_cargo_keys(cfg_map: &BTreeMap<VergenKey, Option<String>>) {
+        let mut count = 0;
+        for (k, v) in cfg_map {
+            match *k {
+                VergenKey::CargoTargetTriple | VergenKey::CargoProfile => {
+                    assert!(v.is_none());
+                    count += 1;
+                }
+                _ => {}
+            }
+        }
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn add_cargo_config_works() {
+        let mut config = Config::default();
+        add_cargo_config(ConstantsFlags::all(), &mut config);
+        check_cargo_keys(config.cfg_map());
+    }
+}

--- a/src/feature/cargo.rs
+++ b/src/feature/cargo.rs
@@ -69,6 +69,7 @@ mod test {
         config::{Config, VergenKey},
         constants::ConstantsFlags,
         test::get_map_value,
+        testutils::{setup, teardown},
     };
     use std::{collections::BTreeMap, env};
 
@@ -94,20 +95,6 @@ mod test {
             }
         }
         assert_eq!(count, 3);
-    }
-
-    fn setup() {
-        env::set_var("TARGET", "x86_64-unknown-linux-gnu");
-        env::set_var("PROFILE", "debug");
-        env::set_var("CARGO_FEATURE_GIT", "git");
-        env::set_var("CARGO_FEATURE_BUILD", "build");
-    }
-
-    fn teardown() {
-        env::remove_var("TARGET");
-        env::remove_var("PROFILE");
-        env::remove_var("CARGO_FEATURE_GIT");
-        env::remove_var("CARGO_FEATURE_BUILD");
     }
 
     #[test]

--- a/src/feature/cargo.rs
+++ b/src/feature/cargo.rs
@@ -96,24 +96,40 @@ mod test {
         assert_eq!(count, 3);
     }
 
+    fn setup() {
+        env::set_var("TARGET", "x86_64-unknown-linux-gnu");
+        env::set_var("PROFILE", "debug");
+        env::set_var("CARGO_FEATURE_GIT", "git");
+        env::set_var("CARGO_FEATURE_BUILD", "build");
+    }
+
+    fn teardown() {
+        env::remove_var("TARGET");
+        env::remove_var("PROFILE");
+        env::remove_var("CARGO_FEATURE_GIT");
+        env::remove_var("CARGO_FEATURE_BUILD");
+    }
+
     #[test]
     fn add_cargo_config_works() {
+        setup();
         let mut config = Config::default();
         add_cargo_config(ConstantsFlags::all(), &mut config);
         check_cargo_keys(config.cfg_map());
         check_cargo_instructions(config.cfg_map());
+        teardown();
     }
 
     #[test]
     fn default_feature_works() {
+        setup();
         env::remove_var("CARGO_FEATURE_GIT");
         env::remove_var("CARGO_FEATURE_BUILD");
         let mut config = Config::default();
         add_cargo_config(ConstantsFlags::all(), &mut config);
         check_cargo_keys(config.cfg_map());
         check_cargo_instructions(config.cfg_map());
-        env::set_var("CARGO_FEATURE_GIT", "git");
-        env::set_var("CARGO_FEATURE_BUILD", "build");
+        teardown();
     }
 }
 

--- a/src/feature/mod.rs
+++ b/src/feature/mod.rs
@@ -8,18 +8,30 @@
 
 //! `vergen` feature implementations
 
-#[cfg(any(feature = "build", feature = "git", feature = "rustc"))]
+#[cfg(any(
+    feature = "build",
+    feature = "cargo",
+    feature = "git",
+    feature = "rustc"
+))]
 use {crate::config::VergenKey, std::collections::BTreeMap};
 
 mod build;
+mod cargo;
 mod git;
 mod rustc;
 
 pub(crate) use build::add_build_config;
+pub(crate) use cargo::add_cargo_config;
 pub(crate) use git::add_git_config;
 pub(crate) use rustc::add_rustc_config;
 
-#[cfg(any(feature = "build", feature = "git", feature = "rustc"))]
+#[cfg(any(
+    feature = "build",
+    feature = "cargo",
+    feature = "git",
+    feature = "rustc"
+))]
 pub(crate) fn add_entry(
     map: &mut BTreeMap<VergenKey, Option<String>>,
     key: VergenKey,
@@ -28,7 +40,15 @@ pub(crate) fn add_entry(
     *map.entry(key).or_insert_with(Option::default) = value;
 }
 
-#[cfg(all(test, any(feature = "build", feature = "git", feature = "rustc")))]
+#[cfg(all(
+    test,
+    any(
+        feature = "build",
+        feature = "cargo",
+        feature = "git",
+        feature = "rustc"
+    )
+))]
 mod test {
     use super::add_entry;
     use crate::config::VergenKey;

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -386,7 +386,7 @@ mod test {
     #[cfg(feature = "rustc")]
     #[rustversion::nightly]
     fn check_rustc_output(stdout: &[u8], stderr: &[u8]) {
-        assert!(RUSTC_NIGHTLY_REGEX.is_match(&String::from_utf8_lossy(&stdout_buf)));
+        assert!(RUSTC_NIGHTLY_REGEX.is_match(&String::from_utf8_lossy(&stdout)));
         assert!(stderr.is_empty());
     }
 

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -97,7 +97,11 @@ fn some_vals<'a>(tuple: (&'a VergenKey, &'a Option<String>)) -> Option<(&VergenK
 #[cfg(test)]
 mod test {
     use super::{gen, gen_cargo_instructions};
-    use crate::{constants::ConstantsFlags, error::Result};
+    use crate::{
+        constants::ConstantsFlags,
+        error::Result,
+        testutils::{setup, teardown},
+    };
     use lazy_static::lazy_static;
     use regex::Regex;
     use std::{io, path::PathBuf};
@@ -107,8 +111,11 @@ mod test {
     }
 
     #[test]
+    #[serial_test::serial]
     fn gen_works() -> Result<()> {
+        setup();
         assert!(gen(ConstantsFlags::all()).is_ok());
+        teardown();
         Ok(())
     }
 

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -369,7 +369,6 @@ mod test {
 
     #[cfg(feature = "rustc")]
     #[test]
-    #[rustversion::nightly]
     fn contains_rustc_output() {
         let repo_path = PathBuf::from(".");
         let mut stdout_buf = vec![];
@@ -381,25 +380,18 @@ mod test {
             &mut stderr_buf
         )
         .is_ok());
-        assert!(RUSTC_NIGHTLY_REGEX.is_match(&String::from_utf8_lossy(&stdout_buf)));
-        assert!(stderr_buf.is_empty());
+        check_rustc_output(&stdout_buf, &stderr_buf);
     }
 
-    #[cfg(feature = "rustc")]
-    #[test]
+    #[rustversion::nightly]
+    fn check_rustc_output(stdout: &[u8], stderr: &[u8]) {
+        assert!(RUSTC_NIGHTLY_REGEX.is_match(&String::from_utf8_lossy(&stdout_buf)));
+        assert!(stderr.is_empty());
+    }
+
     #[rustversion::any(beta, stable)]
-    fn contains_rustc_output() {
-        let repo_path = PathBuf::from(".");
-        let mut stdout_buf = vec![];
-        let mut stderr_buf = vec![];
-        assert!(gen_cargo_instructions(
-            ConstantsFlags::all(),
-            Some(repo_path),
-            &mut stdout_buf,
-            &mut stderr_buf
-        )
-        .is_ok());
-        assert!(RUSTC_REGEX.is_match(&String::from_utf8_lossy(&stdout_buf)));
-        assert!(stderr_buf.is_empty());
+    fn check_rustc_output(stdout: &[u8], stderr: &[u8]) {
+        assert!(!stdout.is_empty());
+        assert!(stderr.is_empty());
     }
 }

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -383,12 +383,14 @@ mod test {
         check_rustc_output(&stdout_buf, &stderr_buf);
     }
 
+    #[cfg(feature = "rustc")]
     #[rustversion::nightly]
     fn check_rustc_output(stdout: &[u8], stderr: &[u8]) {
         assert!(RUSTC_NIGHTLY_REGEX.is_match(&String::from_utf8_lossy(&stdout_buf)));
         assert!(stderr.is_empty());
     }
 
+    #[cfg(feature = "rustc")]
     #[rustversion::any(beta, stable)]
     fn check_rustc_output(stdout: &[u8], stderr: &[u8]) {
         assert!(!stdout.is_empty());

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -117,12 +117,16 @@ mod test {
         static ref TIMESTAMP_RE_STR: &'static str = r#"cargo:rustc-env=VERGEN_BUILD_TIMESTAMP=([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\.[0-9]+)?(([Zz])|([\+|\-]([01][0-9]|2[0-3]):[0-5][0-9]))"#;
         static ref CARGO_SEMVER_RE_STR: &'static str =
             r#"cargo:rustc-env=VERGEN_GIT_SEMVER=\d{1}\.\d{1}\.\d{1}"#;
-        static ref BUILD_CARGO_REGEX: Regex = {
-            let re_str = vec![*DATE_RE_STR, *TIMESTAMP_RE_STR, *CARGO_SEMVER_RE_STR].join("\n");
-            Regex::new(&re_str).unwrap()
-        };
         static ref BUILD_REGEX: Regex = {
             let re_str = vec![*DATE_RE_STR, *TIMESTAMP_RE_STR].join("\n");
+            Regex::new(&re_str).unwrap()
+        };
+    }
+
+    #[cfg(all(feature = "build", not(feature = "git")))]
+    lazy_static! {
+        static ref BUILD_CARGO_REGEX: Regex = {
+            let re_str = vec![*DATE_RE_STR, *TIMESTAMP_RE_STR, *CARGO_SEMVER_RE_STR].join("\n");
             Regex::new(&re_str).unwrap()
         };
     }
@@ -195,17 +199,17 @@ mod test {
             .join("\n");
             Regex::new(&re_str).unwrap()
         };
-        static ref RUSTC_REGEX: Regex = {
-            let re_str = vec![
-                *RUSTC_CHANNEL_RE_STR,
-                *RUSTC_CD_RE_STR,
-                *RUSTC_CH_RE_STR,
-                *RUSTC_HT_RE_STR,
-                *RUSTC_SEMVER_RE_STR,
-            ]
-            .join("\n");
-            Regex::new(&re_str).unwrap()
-        };
+        // static ref RUSTC_REGEX: Regex = {
+        //     let re_str = vec![
+        //         *RUSTC_CHANNEL_RE_STR,
+        //         *RUSTC_CD_RE_STR,
+        //         *RUSTC_CH_RE_STR,
+        //         *RUSTC_HT_RE_STR,
+        //         *RUSTC_SEMVER_RE_STR,
+        //     ]
+        //     .join("\n");
+        //     Regex::new(&re_str).unwrap()
+        // };
     }
 
     #[test]

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -199,17 +199,22 @@ mod test {
             .join("\n");
             Regex::new(&re_str).unwrap()
         };
-        // static ref RUSTC_REGEX: Regex = {
-        //     let re_str = vec![
-        //         *RUSTC_CHANNEL_RE_STR,
-        //         *RUSTC_CD_RE_STR,
-        //         *RUSTC_CH_RE_STR,
-        //         *RUSTC_HT_RE_STR,
-        //         *RUSTC_SEMVER_RE_STR,
-        //     ]
-        //     .join("\n");
-        //     Regex::new(&re_str).unwrap()
-        // };
+    }
+
+    #[cfg(feature = "rustc")]
+    #[rustversion::stable]
+    lazy_static! {
+        static ref RUSTC_REGEX: Regex = {
+            let re_str = vec![
+                *RUSTC_CHANNEL_RE_STR,
+                *RUSTC_CD_RE_STR,
+                *RUSTC_CH_RE_STR,
+                *RUSTC_HT_RE_STR,
+                *RUSTC_SEMVER_RE_STR,
+            ]
+            .join("\n");
+            Regex::new(&re_str).unwrap()
+        };
     }
 
     #[test]
@@ -394,10 +399,19 @@ mod test {
         assert!(stderr.is_empty());
     }
 
+    // TODO: Check this on new beta releases, the regex was causing a panic
+    // outside of my control
     #[cfg(feature = "rustc")]
-    #[rustversion::any(beta, stable)]
+    #[rustversion::beta]
     fn check_rustc_output(stdout: &[u8], stderr: &[u8]) {
         assert!(!stdout.is_empty());
+        assert!(stderr.is_empty());
+    }
+
+    #[cfg(feature = "rustc")]
+    #[rustversion::stable]
+    fn check_rustc_output(stdout: &[u8], stderr: &[u8]) {
+        assert!(RUSTC_REGEX.is_match(&String::from_utf8_lossy(&stdout)));
         assert!(stderr.is_empty());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,24 +259,3 @@ pub(crate) mod test {
             .map_or_else(String::default, identity)
     }
 }
-
-#[cfg(test)]
-use std::env;
-
-#[cfg(test)]
-#[ctor::ctor]
-fn setup() {
-    env::set_var("TARGET", "x86_64-unknown-linux-gnu");
-    env::set_var("PROFILE", "debug");
-    env::set_var("CARGO_FEATURE_GIT", "git");
-    env::set_var("CARGO_FEATURE_BUILD", "build");
-}
-
-#[cfg(test)]
-#[ctor::dtor]
-fn teardown() {
-    env::remove_var("TARGET");
-    env::remove_var("PROFILE");
-    env::remove_var("CARGO_FEATURE_GIT");
-    env::remove_var("CARGO_FEATURE_BUILD");
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,3 +261,22 @@ pub(crate) mod test {
             .map_or_else(String::default, identity)
     }
 }
+
+#[cfg(test)]
+pub(crate) mod testutils {
+    use std::env;
+
+    pub(crate) fn setup() {
+        env::set_var("TARGET", "x86_64-unknown-linux-gnu");
+        env::set_var("PROFILE", "debug");
+        env::set_var("CARGO_FEATURE_GIT", "git");
+        env::set_var("CARGO_FEATURE_BUILD", "build");
+    }
+
+    pub(crate) fn teardown() {
+        env::remove_var("TARGET");
+        env::remove_var("PROFILE");
+        env::remove_var("CARGO_FEATURE_GIT");
+        env::remove_var("CARGO_FEATURE_BUILD");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,6 +234,8 @@ pub use crate::gen::gen;
 
 #[cfg(all(test, not(feature = "rustc")))]
 use rustversion as _;
+#[cfg(all(test, not(feature = "cargo")))]
+use serial_test as _;
 
 #[cfg(all(
     test,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,7 +235,15 @@ pub use crate::gen::gen;
 #[cfg(all(test, not(feature = "rustc")))]
 use rustversion as _;
 
-#[cfg(all(test, any(feature = "build", feature = "git", feature = "rustc")))]
+#[cfg(all(
+    test,
+    any(
+        feature = "build",
+        feature = "cargo",
+        feature = "git",
+        feature = "rustc"
+    )
+))]
 pub(crate) mod test {
     use crate::config::VergenKey;
     use std::{collections::BTreeMap, convert::identity};
@@ -250,4 +258,25 @@ pub(crate) mod test {
             .clone()
             .map_or_else(String::default, identity)
     }
+}
+
+#[cfg(test)]
+use std::env;
+
+#[cfg(test)]
+#[ctor::ctor]
+fn setup() {
+    env::set_var("TARGET", "x86_64-unknown-linux-gnu");
+    env::set_var("PROFILE", "debug");
+    env::set_var("CARGO_FEATURE_GIT", "git");
+    env::set_var("CARGO_FEATURE_BUILD", "build");
+}
+
+#[cfg(test)]
+#[ctor::dtor]
+fn teardown() {
+    env::remove_var("TARGET");
+    env::remove_var("PROFILE");
+    env::remove_var("CARGO_FEATURE_GIT");
+    env::remove_var("CARGO_FEATURE_BUILD");
 }


### PR DESCRIPTION
* There are a handful of cargo variable that are only set a environment variables for build scripts (https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts).  This features writes vergen cargo instructions for the target triple, the profile, and enable features.