### PR TITLE
Release v4.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 name = "vergen"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "4.1.0"
+version = "4.2.0"
 
 [features]
 default = ["build", "cargo", "git", "rustc"]


### PR DESCRIPTION
* `gen` -> `vergen`.   Deprecated the `gen` entrypoint.
* `ConstantsFlags` -> `Config`.  Deprecated the `ConstantsFlags`.
* `ConstantsFlags` were getting bloated, so created `Config`.