### PR TITLE
Make some loose versions in Cargo.toml slightly more accurate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,22 +21,22 @@ rustc = ["rustc_version"]
 
 [dependencies]
 anyhow = "1"
-chrono = { version = "0", optional = true }
+chrono = { version = ">= 0.4, < 1", optional = true }
 enum-iterator = "0"
-getset = "0"
+getset = ">= 0.0.6, < 1"
 git2 = { version = "0", optional = true, default-features = false }
 rustc_version = { version = "0.3.1", optional = true }
 thiserror = "1"
 
 [build-dependencies]
-chrono = "0"
+chrono = ">= 0.4, < 1"
 rustversion = "1"
 
 [dev-dependencies]
 lazy_static = "1"
 regex = "1"
 rustversion = "1"
-serial_test = "0"
+serial_test = ">= 0.4, < 1"
 
 [package.metadata.cargo-all-features]
 skip_optional_dependencies = true


### PR DESCRIPTION
A number of the versions in Cargo.toml were pretty loose (e.g. `"0"`) and I was fairly sure that at least some of them weren't accurate (I knew that `serial_test` almost certainly wasn't). A bit of experimentation later, I've found a series of them that didn't work with the lowest versions that were valid for the listed ranges, and inserted some more precise ranges (while still trying to keep the flexibility where valid).

In theory this could be automatically tested with `cargo +nightly build  -Z minimal-versions` but you end up with issues like early versions of `libssh2-sys` having hyphenated names and having to add a bunch of extra "no, not that version" checks to make it work sadly.