### PR TITLE
fix VERGEN_CARGO_FEATURES

### DIFF
--- a/src/feature/cargo.rs
+++ b/src/feature/cargo.rs
@@ -84,9 +84,9 @@ impl Cargo {
 
 #[cfg(feature = "cargo")]
 fn is_cargo_feature(var: (String, String)) -> Option<String> {
-    let (k, v) = var;
+    let (k, _) = var;
     if k.starts_with("CARGO_FEATURE_") {
-        Some(v)
+        Some(k.replace("CARGO_FEATURE_", "").to_lowercase())
     } else {
         None
     }


### PR DESCRIPTION
The value of CARGO_FEATURE_* environment variable in build scripts is
"1". Thus a value of VERGEN_CARGO_FEATURES becomes something like
"1,1,1".

This commit fixes the 'is_cargo_feature' function to return the feature
name, as it appears in the CARGO_FEATURE_ environment variable name,
instead of the environment variable value, which is constant "1".