### PR TITLE
Updated git docs to include SHA_SHORT and SEMVER_LIGHTWEIGHT

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -156,22 +156,22 @@ pub(crate) enum VergenKey {
     BuildTimestamp,
     /// The build semver. (VERGEN_BUILD_SEMVER)
     BuildSemver,
-    /// The current working branch name (VERGEN_BRANCH)
+    /// The current working branch name (VERGEN_GIT_BRANCH)
     Branch,
-    /// The commit date. (VERGEN_COMMIT_DATE)
+    /// The commit date. (VERGEN_GIT_COMMIT_DATE)
     CommitDate,
-    /// The commit time. (VERGEN_COMMIT_TIME)
+    /// The commit time. (VERGEN_GIT_COMMIT_TIME)
     CommitTime,
-    /// The commit timestamp. (VERGEN_COMMIT_TIMESTAMP)
+    /// The commit timestamp. (VERGEN_GIT_COMMIT_TIMESTAMP)
     CommitTimestamp,
-    /// The semver version from the last git tag. (VERGEN_SEMVER)
+    /// The semver version from the last git tag. (VERGEN_GIT_SEMVER)
     Semver,
     /// The semver version from the last git tag, including lightweight.
-    /// (VERGEN_SEMVER_LIGHTWEIGHT)
+    /// (VERGEN_GIT_SEMVER_LIGHTWEIGHT)
     SemverLightweight,
-    /// The latest commit SHA. (VERGEN_SHA)
+    /// The latest commit SHA. (VERGEN_GIT_SHA)
     Sha,
-    /// The latest commit short SHA. (VERGEN_SHA_SHORT)
+    /// The latest commit short SHA. (VERGEN_GIT_SHA_SHORT)
     ShortSha,
     /// The release channel of the rust compiler. (VERGEN_RUSTC_CHANNEL)
     RustcChannel,

--- a/src/feature/git.rs
+++ b/src/feature/git.rs
@@ -56,7 +56,9 @@ pub enum ShaKind {
 /// | `cargo:rustc-env=VERGEN_GIT_COMMIT_TIME=01:54:15` | |
 /// | `cargo:rustc-env=VERGEN_GIT_COMMIT_TIMESTAMP=2021-02-12T01:54:15.134750+00:00` | * |
 /// | `cargo:rustc-env=VERGEN_GIT_SEMVER=v3.2.0-86-g95fc0f5d` | * |
+/// | `cargo:rustc-env=VERGEN_GIT_SEMVER_LIGHTWEIGHT=feature-test` | |
 /// | `cargo:rustc-env=VERGEN_GIT_SHA=95fc0f5d066710f16e0c23ce3239d6e040abca0d` | * |
+/// | `cargo:rustc-env=VERGEN_GIT_SHA_SHORT=95fc0f5` | |
 /// | `cargo:rerun-if-changed=/Users/yoda/projects/rust-lang/vergen/.git/HEAD` | * |
 /// | `cargo:rerun-if-changed=/Users/yoda/projects/rust-lang/vergen/.git/refs/heads/feature/git2` | * |
 ///
@@ -78,7 +80,7 @@ pub enum ShaKind {
 /// ```
 /// # use anyhow::Result;
 /// use vergen::{vergen, Config};
-#[cfg_attr(feature = "git", doc = r##"use vergen::ShaKind;"##)]
+#[cfg_attr(feature = "git", doc = r##"use vergen::{ShaKind, SemverKind};"##)]
 ///
 /// # pub fn main() -> Result<()> {
 /// let mut config = Config::default();
@@ -87,6 +89,8 @@ pub enum ShaKind {
     doc = r##"
 // Change the SHA output to the short variant
 *config.git_mut().sha_kind_mut() = ShaKind::Short;
+// Change the SEMVER output to the lightweight variant
+*config.git_mut().semver_kind_mut() = SemverKind::Lightweight;
 
 // Generate the instructions
 vergen(config)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,9 @@
 //! | `VERGEN_GIT_COMMIT_TIME` | 20:55:21 |
 //! | `VERGEN_GIT_COMMIT_TIMESTAMP` | 2021-02-24T20:55:21+00:00 |
 //! | `VERGEN_GIT_SEMVER` | 5.0.0-2-gf49246c |
+//! | `VERGEN_GIT_SEMVER_LIGHTWEIGHT` | feature-test |
 //! | `VERGEN_GIT_SHA` | f49246ce334567bff9f950bfd0f3078184a2738a |
+//! | `VERGEN_GIT_SHA_SHORT` | f49246c |
 //! | See [`Rustc`](crate::Rustc) to configure the following |
 //! | `VERGEN_RUSTC_CHANNEL` | nightly |
 //! | `VERGEN_RUSTC_COMMIT_DATE` | 2021-02-24 |
@@ -138,7 +140,7 @@
 //! 1. Ensure you have build scripts enabled via the `build` configuration in your `Cargo.toml`
 //! 1. Add `vergen` as a build dependency, optionally disabling default features in your `Cargo.toml`
 //! 1. Create a `build.rs` file that uses `vergen` to generate `cargo:` instructions.
-//! 1. Use the `env!` macro in your code
+//! 1. Use the [`env!`](std::env!) or [`option_env!`](std::option_env!) macro in your code
 //!
 //! ### Cargo.toml
 //! ```toml


### PR DESCRIPTION
* Added documentation for `VERGEN_GIT_SHA_SHORT` env variable.
* Added documentation for `VERGEN_GIT_SEMVER_LIGHTWEIGHT` env variable.

Fixes #68