### PR TITLE
Check whether files exist before emitting `rerun-if-changed` directive

### DIFF
--- a/src/feature/git.rs
+++ b/src/feature/git.rs
@@ -269,10 +269,18 @@ where
 
             if let Ok(resolved) = ref_head.resolve() {
                 if let Some(name) = resolved.name() {
-                    *config.ref_path_mut() = Some(repo_path.join(name));
+                    let path = repo_path.join(name);
+                    if path.exists() {
+                        *config.ref_path_mut() = Some(repo_path.join(name));
+                    }
                 }
             }
-            *config.head_path_mut() = Some(repo_path.join("HEAD"));
+
+            // Check whether the path exists in the filesystem before emitting it
+            let head_path = repo_path.join("HEAD");
+            if head_path.exists() {
+                *config.head_path_mut() = Some(repo_path.join("HEAD"));
+            }
         }
     }
     Ok(())

--- a/src/feature/git.rs
+++ b/src/feature/git.rs
@@ -276,7 +276,6 @@ where
                     }
                 }
             }
-
             *config.head_path_mut() = Some(repo_path.join("HEAD"));
         }
     }

--- a/src/feature/git.rs
+++ b/src/feature/git.rs
@@ -270,17 +270,14 @@ where
             if let Ok(resolved) = ref_head.resolve() {
                 if let Some(name) = resolved.name() {
                     let path = repo_path.join(name);
+                    // Check whether the path exists in the filesystem before emitting it
                     if path.exists() {
-                        *config.ref_path_mut() = Some(repo_path.join(name));
+                        *config.ref_path_mut() = Some(path);
                     }
                 }
             }
 
-            // Check whether the path exists in the filesystem before emitting it
-            let head_path = repo_path.join("HEAD");
-            if head_path.exists() {
-                *config.head_path_mut() = Some(repo_path.join("HEAD"));
-            }
+            *config.head_path_mut() = Some(repo_path.join("HEAD"));
         }
     }
     Ok(())


### PR DESCRIPTION
I noticed that vergen is causing my rust project to always rebuild, and I traced it down to a `rerun-if-changed` directive that points to a nonexistent file. 

This causes `cargo` to assume that the file was just deleted and needs to rebuild. With this patch, we only emit `rerun-if-changed` if the files actually exist.

I've tested this by wiring it up to my project and it fixes the constant rebuild problem.