### PR TITLE
Disable the Rayon dep for sysinfo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ enum-iterator = "0"
 getset = "0"
 git2 = { version = "0", optional = true, default-features = false }
 rustc_version = { version = "0.3.1", optional = true }
-sysinfo = { version = "0", optional = true }
+sysinfo = { version = "0", optional = true, default-features = false }
 thiserror = "1"
 
 [build-dependencies]


### PR DESCRIPTION
With default features sysinfo will pull in rayon, which isn't very nice for build times.

build.rs scripts aren't supposed to use more than one CPU anyway, see https://doc.rust-lang.org/cargo/reference/build-scripts.html#jobserver