### PR TITLE
Replace rustc commit hash/date when not present

### DIFF
--- a/src/feature/rustc.rs
+++ b/src/feature/rustc.rs
@@ -150,7 +150,7 @@ pub(crate) fn configure_rustc(instructions: Instructions, config: &mut Config) -
             add_entry(
                 config.cfg_map_mut(),
                 VergenKey::RustcCommitHash,
-                rustc.commit_hash,
+                Some(rustc.commit_hash.unwrap_or_else(|| "unknown".to_string())),
             );
         }
 
@@ -158,7 +158,7 @@ pub(crate) fn configure_rustc(instructions: Instructions, config: &mut Config) -
             add_entry(
                 config.cfg_map_mut(),
                 VergenKey::RustcCommitDate,
-                rustc.commit_date,
+                Some(rustc.commit_date.unwrap_or_else(|| "unknown".to_string())),
             );
         }
 


### PR DESCRIPTION
Occasionally `rustc -vV` (used by `rustc_version`) will return `unknown`
for the commit date and/or hash. In `rustc_version::VersionMeta`, this
is represented as a `None` value in the `commit_hash` and `commit_date`
fields. This is a problem if these variables are depended on by the
application, as vergen will not panic if they are not present, but will
instead silently omit them.

This PR fixes this issue by replacing a `None` value for a commit hash
or date with the string "unknown".

Fixes #78