### PR TITLE
Pin `sysinfo` to the lowest supported version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ enum-iterator = "0"
 getset = "0"
 git2 = { version = "0", optional = true, default-features = false }
 rustc_version = { version = "0.4.0", optional = true }
-sysinfo = { version = "0", optional = true, default-features = false }
+sysinfo = { version = "0.19", optional = true, default-features = false }
 thiserror = "1"
 
 [build-dependencies]


### PR DESCRIPTION
* Pin `sysinfo` to 0.19

Fixes #80 