### PR TITLE
fix little confusing build.rs in documentation comment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@
 //! ### build.rs
 //! **NOTE** - Individual instruction generation can be toggled on or off via [`Config`](crate::Config)
 //! ```
-//! # use anyhow::Result;
+//! use anyhow::Result;
 //! use vergen::{Config, vergen};
 //!
 //! fn main() -> Result<()> {


### PR DESCRIPTION
We couldn't determine `Result` is `anyhow::Result` from rendered documentation. It's little confusing.

https://docs.rs/vergen/5.1.13/vergen/