### PR TITLE
Don't require old time dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ si = ["sysinfo"]
 [dependencies]
 anyhow = "1"
 cfg-if = "1"
-chrono = { version = "0", optional = true }
+chrono = { version = "0", optional = true, default-features = false }
 enum-iterator = "0"
 getset = "0"
 git2 = { version = "0", optional = true, default-features = false }


### PR DESCRIPTION
A default feature in Chrono pulls in `time` v0.1, which is completely unnecessary for this crate, and on top of that currently it's marked by rustsec as vulnerable and unfixable.

