### PR TITLE
Replace chrono with time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,16 +14,16 @@ version = "6.0.0"
 
 [features]
 default = ["build", "cargo", "git", "rustc", "si"]
-build = ["chrono"]
+build = ["time"]
 cargo = []
-git = ["chrono", "git2"]
+git = ["git2", "time"]
 rustc = ["rustc_version"]
 si = ["sysinfo"]
 
 [dependencies]
 anyhow = "1"
 cfg-if = "1"
-chrono = { version = "0", optional = true, default-features = false }
+time = { version = "0.3", optional = true, features = ["local-offset", "formatting", "macros"] }
 enum-iterator = "0"
 getset = "0"
 git2 = { version = "0", optional = true, default-features = false }
@@ -32,7 +32,7 @@ sysinfo = { version = "=0.19", optional = true, default-features = false }
 thiserror = "1"
 
 [build-dependencies]
-chrono = "0"
+time = { version = "0.3", features = ["formatting"] }
 rustversion = "1"
 
 [dev-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,13 @@
-use chrono::Utc;
+use time::format_description;
 
 pub fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     // These are here so some doc tests work
-    let now = Utc::now();
+    let now = time::OffsetDateTime::now_utc();
     println!(
         "cargo:rustc-env=VERGEN_BUILD_TIMESTAMP={}",
-        now.to_rfc3339()
+        now.format(&format_description::well_known::Rfc3339)
+            .unwrap()
     );
     println!("cargo:rustc-env=VERGEN_GIT_SEMVER=v3.2.0-86-g95fc0f5");
     nightly_lints();

--- a/src/feature/build.rs
+++ b/src/feature/build.rs
@@ -15,9 +15,9 @@ use {
         config::VergenKey,
         feature::{add_entry, TimeZone, TimestampKind},
     },
-    chrono::{DateTime, Local, Utc},
     getset::{Getters, MutGetters},
     std::env,
+    time::{format_description, macros::format_description, OffsetDateTime},
 };
 
 /// Configuration for the `VERGEN_BUILD_*` instructions
@@ -103,8 +103,16 @@ pub(crate) fn configure_build(instructions: &Instructions, config: &mut Config) 
     if build_config.has_enabled() {
         if *build_config.timestamp() {
             match build_config.timezone() {
-                TimeZone::Utc => add_config_entries(config, *build_config, &Utc::now()),
-                TimeZone::Local => add_config_entries(config, *build_config, &Local::now()),
+                TimeZone::Utc => {
+                    add_config_entries(config, *build_config, &OffsetDateTime::now_utc());
+                }
+                TimeZone::Local => {
+                    add_config_entries(
+                        config,
+                        *build_config,
+                        &OffsetDateTime::now_local().expect("unable to retrieve local datetime"),
+                    );
+                }
             };
         }
 
@@ -119,11 +127,7 @@ pub(crate) fn configure_build(instructions: &Instructions, config: &mut Config) 
 }
 
 #[cfg(feature = "build")]
-fn add_config_entries<T>(config: &mut Config, build_config: Build, now: &DateTime<T>)
-where
-    T: chrono::TimeZone,
-    T::Offset: std::fmt::Display,
-{
+fn add_config_entries(config: &mut Config, build_config: Build, now: &OffsetDateTime) {
     match build_config.kind() {
         TimestampKind::DateOnly => add_date_entry(config, now),
         TimestampKind::TimeOnly => add_time_entry(config, now),
@@ -141,41 +145,30 @@ where
 }
 
 #[cfg(feature = "build")]
-fn add_date_entry<T>(config: &mut Config, now: &DateTime<T>)
-where
-    T: chrono::TimeZone,
-    T::Offset: std::fmt::Display,
-{
+fn add_date_entry(config: &mut Config, now: &OffsetDateTime) {
     add_entry(
         config.cfg_map_mut(),
         VergenKey::BuildDate,
-        Some(now.format("%Y-%m-%d").to_string()),
+        now.format(format_description!("[year]-[month]-[day]")).ok(),
     );
 }
 
 #[cfg(feature = "build")]
-fn add_time_entry<T>(config: &mut Config, now: &DateTime<T>)
-where
-    T: chrono::TimeZone,
-    T::Offset: std::fmt::Display,
-{
+fn add_time_entry(config: &mut Config, now: &OffsetDateTime) {
     add_entry(
         config.cfg_map_mut(),
         VergenKey::BuildTime,
-        Some(now.format("%H:%M:%S").to_string()),
+        now.format(format_description!("[hour]-[minute]-[second]"))
+            .ok(),
     );
 }
 
 #[cfg(feature = "build")]
-fn add_timestamp_entry<T>(config: &mut Config, now: &DateTime<T>)
-where
-    T: chrono::TimeZone,
-    T::Offset: std::fmt::Display,
-{
+fn add_timestamp_entry(config: &mut Config, now: &OffsetDateTime) {
     add_entry(
         config.cfg_map_mut(),
         VergenKey::BuildTimestamp,
-        Some(now.to_rfc3339()),
+        now.format(&format_description::well_known::Rfc3339).ok(),
     );
 }
 


### PR DESCRIPTION
Replaces `chrono` with `time`.
Thank you for this crate btw :).

fixes https://github.com/rustyhorde/vergen/issues/94