### PR TITLE
Fix msrv_lints version

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -39,7 +39,7 @@ fn stable_lints() {
 #[rustversion::not(stable)]
 fn stable_lints() {}
 
-#[rustversion::before(1.57)]
+#[rustversion::before(1.58)]
 fn msrv_lints() {}
 
 #[rustversion::since(1.58)]


### PR DESCRIPTION
Before and since have to use the same version, right now 1.57 is excluded so it
cannot find msrv_lints().

Fixes #105
