### PR TITLE
Draft: Replace `chrono` with `time`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,30 +13,31 @@ repository = "https://github.com/rustyhorde/vergen"
 version = "6.0.2"
 
 [package.metadata.cargo-all-features]
-denylist = ["chrono","git2","rustc_version","sysinfo"]
+denylist = ["time","git2","rustc_version","sysinfo"]
 
 [features]
 default = ["build", "cargo", "git", "rustc", "si"]
-build = ["chrono"]
+build = ["time"]
 cargo = []
-git = ["chrono", "git2"]
+git = ["time", "git2"]
 rustc = ["rustc_version"]
 si = ["sysinfo"]
 
 [dependencies]
 anyhow = "1"
 cfg-if = "1"
-chrono = { version = "0", optional = true, default-features = false }
 enum-iterator = "0"
 getset = "0"
 git2 = { version = "0", optional = true, default-features = false }
 rustc_version = { version = "0.4.0", optional = true }
 sysinfo = { version = "=0.23", optional = true, default-features = false }
 thiserror = "1"
+time = { version = "0.3.7", features = ["local-offset"], default-features = false, optional = true }
+
 
 [build-dependencies]
-chrono = "0"
 rustversion = "1"
+time = { version = "0.3.7", features = ["formatting"], default-features = false }
 
 [dev-dependencies]
 lazy_static = "1"

--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,13 @@
-use chrono::Utc;
+// use chrono::Utc;
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 pub fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     // These are here so some doc tests work
-    let now = Utc::now();
+    let now = OffsetDateTime::now_utc();
     println!(
         "cargo:rustc-env=VERGEN_BUILD_TIMESTAMP={}",
-        now.to_rfc3339()
+        now.format(&Rfc3339).unwrap()
     );
     println!("cargo:rustc-env=VERGEN_GIT_SEMVER=v3.2.0-86-g95fc0f5");
     nightly_lints();

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,3 @@
-// use chrono::Utc;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 pub fn main() {

--- a/src/feature/git.rs
+++ b/src/feature/git.rs
@@ -225,15 +225,6 @@ where
 
                 if *git_config.commit_timestamp() {
                     let commit_time = OffsetDateTime::from_unix_timestamp(commit.time().seconds())?;
-                    // let offset = if commit.time().sign() == '-' {
-                    //     // FixedOffset::west(commit.time().offset_minutes() * 60)
-                    //     //     .timestamp(commit.time().seconds(), 0)
-                    //     UtcOffset::from_hms(0, -commit.time().offset_minutes(), 0).unwrap()
-                    // } else {
-                    //     // FixedOffset::east(commit.time().offset_minutes() * 60)
-                    //     //     .timestamp(commit.time().seconds(), 0)
-                    //     UtcOffset::from_hms(0, commit.time().offset_minutes(), 0).unwrap()
-                    // };
 
                     match git_config.commit_timestamp_timezone() {
                         crate::TimeZone::Utc => {


### PR DESCRIPTION
As described in https://github.com/rustyhorde/vergen/issues/94, the `chrono` crate seems unmaintained and has [a public and unfixed advisory](https://github.com/rustsec/advisory-db/blob/main/crates/chrono/RUSTSEC-2020-0159.md)

This change tries to replace `chrono` with the current version of the `time` crate.

All tests except the ones using the local timezone are still passing. The current failures seem to relate to https://github.com/time-rs/time/issues/427 and need to be investigated further. Maybe the function signatures need to change to return `Result`, so possible errors can be handled.