### PR TITLE
`chrono` replaced with `time`,  `local_offset` feature flag added

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,29 +13,31 @@ repository = "https://github.com/rustyhorde/vergen"
 version = "6.0.2"
 
 [package.metadata.cargo-all-features]
-denylist = ["chrono","git2","rustc_version","sysinfo"]
+denylist = ["local_offset","time","git2","rustc_version","sysinfo"]
 
 [features]
 default = ["build", "cargo", "git", "rustc", "si"]
-build = ["chrono"]
+build = ["time"]
 cargo = []
-git = ["chrono", "git2"]
+git = ["time", "git2"]
 rustc = ["rustc_version"]
 si = ["sysinfo"]
+local_offset = ["time/local-offset"]
 
 [dependencies]
 anyhow = "1"
 cfg-if = "1"
-chrono = { version = "0", optional = true, default-features = false }
 enum-iterator = "0"
 getset = "0"
 git2 = { version = "0", optional = true, default-features = false }
 rustc_version = { version = "0.4.0", optional = true }
 sysinfo = { version = "=0.23", optional = true, default-features = false }
 thiserror = "1"
+time = { version = "0.3.7", optional = true }
 
 [build-dependencies]
-chrono = "0"
+anyhow = "1.0.56"
+time = { version = "0.3.7", features = ["formatting"] }
 rustversion = "1"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ Generate `build`, `git`, `rustc`, `cargo`, and `sysinfo` related [`cargo:rustc-e
 Special thanks to the sponsors of this project
 * [tyretool](https://github.com/tryretool)
 
+## Release 7.0 Breaking Changes
+* `chrono` has been replaced with `time`. The `time` crate is better maintained.
+* The local timezone support in the `build` and `git` features has been moved behind a `local_offset` feature flag.  This is
+due to a [potential segfault](https://github.com/rustsec/advisory-db/blob/main/crates/time/RUSTSEC-2020-0071.md) when using `localtime_r` as the `time` crate does.
+* To build with the `local_offset` feature, you must also explicitly delare that you are acknowledging the potential unsoundness by
+setting `RUSTFLAGS="--cfg unsound_local_offset"`.  Per the `time` docs this isn't tested, so use with extreme caution.
+
 ## Release 6.0 Breaking Changes
 * The `Copy` implementation was dropped from the [`Config`](https://github.com/rustyhorde/vergen/blob/24ed6bc2269320ab98962edc8b736fcc6e3c7d64/src/config.rs#L94-L148) struct to allow the base git directory to be specified.  This is a breaking API change necessitating a new major release.
 ## Current Release

--- a/build.rs
+++ b/build.rs
@@ -1,18 +1,20 @@
-use chrono::Utc;
+use anyhow::Result;
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
-pub fn main() {
+pub fn main() -> Result<()> {
     println!("cargo:rerun-if-changed=build.rs");
     // These are here so some doc tests work
-    let now = Utc::now();
+    let now = OffsetDateTime::now_utc();
     println!(
         "cargo:rustc-env=VERGEN_BUILD_TIMESTAMP={}",
-        now.to_rfc3339()
+        now.format(&Rfc3339)?
     );
     println!("cargo:rustc-env=VERGEN_GIT_SEMVER=v3.2.0-86-g95fc0f5");
     nightly_lints();
     beta_lints();
     stable_lints();
     msrv_lints();
+    Ok(())
 }
 
 #[rustversion::nightly]

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,7 +52,7 @@ use std::{
 ///
 /// ```
 /// use vergen::Config;
-#[cfg_attr(feature = "git", doc = r##"use vergen::TimeZone;"##)]
+#[cfg_attr(feature = "git", doc = r##"use vergen::ShaKind;"##)]
 ///
 /// let mut config = Config::default();
 #[cfg_attr(
@@ -65,8 +65,8 @@ use std::{
 #[cfg_attr(
     feature = "git",
     doc = r##"
-// Change the commit timestamp timezone to local
-*config.git_mut().commit_timestamp_timezone_mut() = TimeZone::Local;
+// Change the SHA output to the short variant
+*config.git_mut().sha_kind_mut() = ShaKind::Short;
 "##
 )]
 #[cfg_attr(
@@ -137,7 +137,7 @@ impl Instructions {
     {
         let mut config = Config::default();
 
-        configure_build(&self, &mut config);
+        configure_build(&self, &mut config)?;
         configure_git(&self, repo_path, &mut config)?;
         configure_rustc(&self, &mut config)?;
         configure_cargo(&self, &mut config);

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,6 +53,10 @@ use std::{
 /// ```
 /// use vergen::Config;
 #[cfg_attr(feature = "git", doc = r##"use vergen::ShaKind;"##)]
+#[cfg_attr(
+    all(feature = "git", feature = "local_offset"),
+    doc = r##"use vergen::TimeZone;"##
+)]
 ///
 /// let mut config = Config::default();
 #[cfg_attr(
@@ -67,6 +71,14 @@ use std::{
     doc = r##"
 // Change the SHA output to the short variant
 *config.git_mut().sha_kind_mut() = ShaKind::Short;
+"##
+)]
+#[cfg_attr(
+    all(feature = "git", feature = "local_offset"),
+    doc = r##"
+// Change the SHA output to the short variant
+*config.git_mut().sha_kind_mut() = ShaKind::Short;
+*config.git_mut().commit_timestamp_timezone_mut() = TimeZone::Local;
 "##
 )]
 #[cfg_attr(

--- a/src/feature/build.rs
+++ b/src/feature/build.rs
@@ -44,6 +44,7 @@ use {
 /// # use anyhow::Result;
 /// use vergen::{vergen, Config};
 #[cfg_attr(feature = "build", doc = r##"use vergen::TimestampKind;"##)]
+#[cfg_attr(all(feature = "build", feature = "local_offset"), doc = r##"use vergen::TimeZone;"##)]
 ///
 /// # pub fn main() -> Result<()> {
 /// let mut config = Config::default();
@@ -52,6 +53,18 @@ use {
     doc = r##"
 // Generate all three date/time instructions
 *config.build_mut().kind_mut() = TimestampKind::All;
+
+// Generate the instructions
+vergen(config)?;
+"##
+)]
+#[cfg_attr(
+    all(feature = "build", feature = "local_offset"),
+    doc = r##"
+// Generate all three date/time instructions
+*config.build_mut().kind_mut() = TimestampKind::All;
+// Generate the output time in the local timezone
+*config.build_mut().timezone_mut() = TimeZone::Local;
 
 // Generate the instructions
 vergen(config)?;

--- a/src/feature/build.rs
+++ b/src/feature/build.rs
@@ -9,15 +9,16 @@
 //! `vergen` build feature implementation
 
 use crate::config::{Config, Instructions};
+use anyhow::Result;
 #[cfg(feature = "build")]
 use {
     crate::{
         config::VergenKey,
         feature::{add_entry, TimeZone, TimestampKind},
     },
-    chrono::{DateTime, Local, Utc},
     getset::{Getters, MutGetters},
     std::env,
+    time::{format_description, OffsetDateTime},
 };
 
 /// Configuration for the `VERGEN_BUILD_*` instructions
@@ -42,7 +43,7 @@ use {
 /// ```
 /// # use anyhow::Result;
 /// use vergen::{vergen, Config};
-#[cfg_attr(feature = "build", doc = r##"use vergen::{TimestampKind, TimeZone};"##)]
+#[cfg_attr(feature = "build", doc = r##"use vergen::TimestampKind;"##)]
 ///
 /// # pub fn main() -> Result<()> {
 /// let mut config = Config::default();
@@ -51,8 +52,6 @@ use {
     doc = r##"
 // Generate all three date/time instructions
 *config.build_mut().kind_mut() = TimestampKind::All;
-// Change the date/time instructions to show `Local` time
-*config.build_mut().timezone_mut() = TimeZone::Local;
 
 // Generate the instructions
 vergen(config)?;
@@ -97,14 +96,19 @@ impl Build {
 }
 
 #[cfg(feature = "build")]
-pub(crate) fn configure_build(instructions: &Instructions, config: &mut Config) {
+pub(crate) fn configure_build(instructions: &Instructions, config: &mut Config) -> Result<()> {
     let build_config = instructions.build();
 
     if build_config.has_enabled() {
         if *build_config.timestamp() {
             match build_config.timezone() {
-                TimeZone::Utc => add_config_entries(config, *build_config, &Utc::now()),
-                TimeZone::Local => add_config_entries(config, *build_config, &Local::now()),
+                TimeZone::Utc => {
+                    add_config_entries(config, *build_config, &OffsetDateTime::now_utc())?;
+                }
+                #[cfg(feature = "local_offset")]
+                TimeZone::Local => {
+                    add_config_entries(config, *build_config, &OffsetDateTime::now_local()?)?;
+                }
             };
         }
 
@@ -116,71 +120,70 @@ pub(crate) fn configure_build(instructions: &Instructions, config: &mut Config) 
             );
         }
     }
+    Ok(())
 }
 
 #[cfg(feature = "build")]
-fn add_config_entries<T>(config: &mut Config, build_config: Build, now: &DateTime<T>)
-where
-    T: chrono::TimeZone,
-    T::Offset: std::fmt::Display,
-{
+fn add_config_entries(
+    config: &mut Config,
+    build_config: Build,
+    now: &OffsetDateTime,
+) -> Result<()> {
     match build_config.kind() {
-        TimestampKind::DateOnly => add_date_entry(config, now),
-        TimestampKind::TimeOnly => add_time_entry(config, now),
+        TimestampKind::DateOnly => add_date_entry(config, now)?,
+        TimestampKind::TimeOnly => add_time_entry(config, now)?,
         TimestampKind::DateAndTime => {
-            add_date_entry(config, now);
-            add_time_entry(config, now);
+            add_date_entry(config, now)?;
+            add_time_entry(config, now)?;
         }
-        TimestampKind::Timestamp => add_timestamp_entry(config, now),
+        TimestampKind::Timestamp => add_timestamp_entry(config, now)?,
         TimestampKind::All => {
-            add_date_entry(config, now);
-            add_time_entry(config, now);
-            add_timestamp_entry(config, now);
+            add_date_entry(config, now)?;
+            add_time_entry(config, now)?;
+            add_timestamp_entry(config, now)?;
         }
     }
+    Ok(())
 }
 
 #[cfg(feature = "build")]
-fn add_date_entry<T>(config: &mut Config, now: &DateTime<T>)
-where
-    T: chrono::TimeZone,
-    T::Offset: std::fmt::Display,
-{
+fn add_date_entry(config: &mut Config, now: &OffsetDateTime) -> Result<()> {
+    let format = format_description::parse("[year]-[month]-[day]")?;
     add_entry(
         config.cfg_map_mut(),
         VergenKey::BuildDate,
-        Some(now.format("%Y-%m-%d").to_string()),
+        Some(now.format(&format)?),
     );
+    Ok(())
 }
 
 #[cfg(feature = "build")]
-fn add_time_entry<T>(config: &mut Config, now: &DateTime<T>)
-where
-    T: chrono::TimeZone,
-    T::Offset: std::fmt::Display,
-{
+fn add_time_entry(config: &mut Config, now: &OffsetDateTime) -> Result<()> {
+    let format = format_description::parse("[hour]:[minute]:[second]")?;
     add_entry(
         config.cfg_map_mut(),
         VergenKey::BuildTime,
-        Some(now.format("%H:%M:%S").to_string()),
+        Some(now.format(&format)?),
     );
+    Ok(())
 }
 
 #[cfg(feature = "build")]
-fn add_timestamp_entry<T>(config: &mut Config, now: &DateTime<T>)
-where
-    T: chrono::TimeZone,
-    T::Offset: std::fmt::Display,
-{
+fn add_timestamp_entry(config: &mut Config, now: &OffsetDateTime) -> Result<()> {
+    use time::format_description::well_known::Rfc3339;
+
     add_entry(
         config.cfg_map_mut(),
         VergenKey::BuildTimestamp,
-        Some(now.to_rfc3339()),
+        Some(now.format(&Rfc3339)?),
     );
+    Ok(())
 }
 
 #[cfg(not(feature = "build"))]
-pub(crate) fn configure_build(_instructions: &Instructions, _config: &mut Config) {}
+pub(crate) fn configure_build(_instructions: &Instructions, _config: &mut Config) -> Result<()> {
+    Ok(())
+}
 
 #[cfg(all(test, feature = "build"))]
 mod test {

--- a/src/feature/build.rs
+++ b/src/feature/build.rs
@@ -44,7 +44,10 @@ use {
 /// # use anyhow::Result;
 /// use vergen::{vergen, Config};
 #[cfg_attr(feature = "build", doc = r##"use vergen::TimestampKind;"##)]
-#[cfg_attr(all(feature = "build", feature = "local_offset"), doc = r##"use vergen::TimeZone;"##)]
+#[cfg_attr(
+    all(feature = "build", feature = "local_offset"),
+    doc = r##"use vergen::TimeZone;"##
+)]
 ///
 /// # pub fn main() -> Result<()> {
 /// let mut config = Config::default();

--- a/src/feature/git.rs
+++ b/src/feature/git.rs
@@ -18,10 +18,13 @@ use {
         error::Error,
         feature::{self, add_entry, TimestampKind},
     },
-    chrono::{DateTime, FixedOffset, Local, TimeZone, Utc},
     getset::{CopyGetters, Getters, MutGetters},
     git2::{BranchType, DescribeFormatOptions, DescribeOptions, Repository},
     std::{env, path::PathBuf},
+    time::{
+        format_description::{self, well_known::Rfc3339},
+        OffsetDateTime, UtcOffset,
+    },
 };
 
 /// The semver kind to output
@@ -224,20 +227,23 @@ where
                 let commit = ref_head.peel_to_commit()?;
 
                 if *git_config.commit_timestamp() {
-                    let offset = if commit.time().sign() == '-' {
-                        FixedOffset::west(commit.time().offset_minutes() * 60)
-                            .timestamp(commit.time().seconds(), 0)
-                    } else {
-                        FixedOffset::east(commit.time().offset_minutes() * 60)
-                            .timestamp(commit.time().seconds(), 0)
-                    };
+                    let commit_time = OffsetDateTime::from_unix_timestamp(commit.time().seconds())?;
 
                     match git_config.commit_timestamp_timezone() {
                         crate::TimeZone::Utc => {
-                            add_config_entries(config, git_config, &offset.with_timezone(&Utc));
+                            add_config_entries(
+                                config,
+                                git_config,
+                                &commit_time.to_offset(UtcOffset::UTC),
+                            )?;
                         }
+                        #[cfg(feature = "local_offset")]
                         crate::TimeZone::Local => {
-                            add_config_entries(config, git_config, &offset.with_timezone(&Local));
+                            add_config_entries(
+                                config,
+                                git_config,
+                                &commit_time.to_offset(UtcOffset::current_local_offset()?),
+                            )?;
                         }
                     }
                 }
@@ -308,64 +314,54 @@ where
 }
 
 #[cfg(feature = "git")]
-fn add_config_entries<T>(config: &mut Config, git_config: &Git, now: &DateTime<T>)
-where
-    T: TimeZone,
-    T::Offset: std::fmt::Display,
-{
+fn add_config_entries(config: &mut Config, git_config: &Git, now: &OffsetDateTime) -> Result<()> {
     match git_config.commit_timestamp_kind() {
-        TimestampKind::DateOnly => add_date_entry(config, now),
-        TimestampKind::TimeOnly => add_time_entry(config, now),
+        TimestampKind::DateOnly => add_date_entry(config, now)?,
+        TimestampKind::TimeOnly => add_time_entry(config, now)?,
         TimestampKind::DateAndTime => {
-            add_date_entry(config, now);
-            add_time_entry(config, now);
+            add_date_entry(config, now)?;
+            add_time_entry(config, now)?;
         }
-        TimestampKind::Timestamp => add_timestamp_entry(config, now),
+        TimestampKind::Timestamp => add_timestamp_entry(config, now)?,
         TimestampKind::All => {
-            add_date_entry(config, now);
-            add_time_entry(config, now);
-            add_timestamp_entry(config, now);
+            add_date_entry(config, now)?;
+            add_time_entry(config, now)?;
+            add_timestamp_entry(config, now)?;
         }
     }
+    Ok(())
 }
 
 #[cfg(feature = "git")]
-fn add_date_entry<T>(config: &mut Config, now: &DateTime<T>)
-where
-    T: TimeZone,
-    T::Offset: std::fmt::Display,
-{
+fn add_date_entry(config: &mut Config, now: &OffsetDateTime) -> Result<()> {
+    let format = format_description::parse("[year]-[month]-[day]")?;
     add_entry(
         config.cfg_map_mut(),
         VergenKey::CommitDate,
-        Some(now.format("%Y-%m-%d").to_string()),
+        Some(now.format(&format)?),
     );
+    Ok(())
 }
 
 #[cfg(feature = "git")]
-fn add_time_entry<T>(config: &mut Config, now: &DateTime<T>)
-where
-    T: TimeZone,
-    T::Offset: std::fmt::Display,
-{
+fn add_time_entry(config: &mut Config, now: &OffsetDateTime) -> Result<()> {
+    let format = format_description::parse("[hour]:[minute]:[second]")?;
     add_entry(
         config.cfg_map_mut(),
         VergenKey::CommitTime,
-        Some(now.format("%H:%M:%S").to_string()),
+        Some(now.format(&format)?),
     );
+    Ok(())
 }
 
 #[cfg(feature = "git")]
-fn add_timestamp_entry<T>(config: &mut Config, now: &DateTime<T>)
-where
-    T: TimeZone,
-    T::Offset: std::fmt::Display,
-{
+fn add_timestamp_entry(config: &mut Config, now: &OffsetDateTime) -> Result<()> {
     add_entry(
         config.cfg_map_mut(),
         VergenKey::CommitTimestamp,
-        Some(now.to_rfc3339()),
+        Some(now.format(&Rfc3339)?),
     );
+    Ok(())
 }
 
 #[cfg(feature = "git")]

--- a/src/feature/mod.rs
+++ b/src/feature/mod.rs
@@ -60,6 +60,7 @@ pub(crate) fn add_entry(
 pub enum TimeZone {
     /// UTC
     Utc,
+    #[cfg(feature = "local_offset")]
     /// Local
     Local,
 }

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -542,7 +542,7 @@ mod test {
         assert!(!RUSTC_REGEX.is_match(&String::from_utf8_lossy(&stdout)));
     }
 
-    #[cfg(feature = "build")]
+    #[cfg(all(feature = "build", feature = "local_offset"))]
     #[test]
     fn build_local_timezone() {
         use super::config_from_instructions;
@@ -555,7 +555,7 @@ mod test {
         assert!(config_from_instructions(config, Some(repo_path), &mut stdout_buf,).is_ok());
     }
 
-    #[cfg(feature = "git")]
+    #[cfg(all(feature = "git", feature = "local_offset"))]
     #[test]
     fn git_local_timezone() {
         use super::config_from_instructions;


### PR DESCRIPTION
* `chrono` has been replace with `time` as the `time` crate is better maintained.
* Added a `local_offset` feature flag.  Using this will enable the local timezone features in the `git` and `build` features.  However, due to a [potential segfault](https://github.com/rustsec/advisory-db/blob/main/crates/time/RUSTSEC-2020-0071.md) in the `time` crate, you must also explicitly opt in to the unsoundness by setting `RUSTFLAGS="--cfg unsound_local_offset"`.   Per the `time` crate docs, this is untested, so use with extreme caution.