### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ local_offset = ["time/local-offset"]
 anyhow = "1"
 cfg-if = "1"
 enum-iterator = "1.1.3"
-getset = "0"
+getset = "0.2"
 git2 = { version = "0.14", optional = true, default-features = false }
 rustc_version = { version = "0.4.0", optional = true }
 sysinfo = { version = "0.24.7", optional = true, default-features = false }
@@ -43,5 +43,4 @@ rustversion = "1"
 [dev-dependencies]
 lazy_static = "1"
 regex = "1"
-serial_test = "0"
-
+serial_test = "0.8"


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.