### PR TITLE
Add option to continue if an Error occurs in one section

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,4 +44,5 @@ rustversion = "1"
 lazy_static = "1"
 regex = "1"
 serial_test = "0"
+tempfile = "3"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -356,6 +356,7 @@ mod test {
         assert_eq!(*config.semver_kind(), SemverKind::Normal);
         assert!(config.sha());
         assert_eq!(*config.sha_kind(), ShaKind::Normal);
+        assert!(!config.skip_if_error());
     }
 
     #[cfg(not(feature = "git"))]

--- a/src/config.rs
+++ b/src/config.rs
@@ -283,6 +283,7 @@ pub(crate) struct Config {
     cfg_map: BTreeMap<VergenKey, Option<String>>,
     head_path: Option<PathBuf>,
     ref_path: Option<PathBuf>,
+    warnings: Vec<String>,
 }
 
 impl Default for Config {
@@ -296,6 +297,7 @@ impl Default for Config {
                 .collect(),
             head_path: Option::default(),
             ref_path: Option::default(),
+            warnings: Vec::new(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -321,6 +321,7 @@ mod test {
         assert_eq!(*config.timezone(), TimeZone::Utc);
         assert_eq!(*config.kind(), TimestampKind::Timestamp);
         assert!(config.semver());
+        assert!(!config.skip_if_error());
     }
 
     #[cfg(not(feature = "build"))]

--- a/src/config.rs
+++ b/src/config.rs
@@ -386,6 +386,7 @@ mod test {
         assert!(config.memory());
         assert!(config.cpu_vendor());
         assert!(config.cpu_core_count());
+        assert!(!config.skip_if_error());
     }
 
     #[cfg(not(feature = "si"))]

--- a/src/config.rs
+++ b/src/config.rs
@@ -371,6 +371,7 @@ mod test {
         assert!(config.host_triple());
         assert!(config.llvm_version());
         assert!(config.sha());
+        assert!(!config.skip_if_error());
     }
 
     #[cfg(not(feature = "rustc"))]

--- a/src/feature/build.rs
+++ b/src/feature/build.rs
@@ -37,6 +37,8 @@ use {
 /// * If the `semver` field is false, the semver instruction will not be generated.
 /// * **NOTE** - By default, the date/time related instructions will use [`UTC`](TimeZone::Utc).
 /// * **NOTE** - The date/time instruction output is determined by the [`kind`](TimestampKind) field and can be any combination of the three.
+/// * **NOTE** - To keep processing other sections if an Error occurs in this one, set
+///     [`Build::skip_if_error`](Build::skip_if_error_mut()) to true.
 ///
 /// # Example
 ///
@@ -90,6 +92,7 @@ pub struct Build {
     /// Enable/Disable the `VERGEN_BUILD_SEMVER` instruction.
     semver: bool,
     /// Enable/Disable skipping [`Build`] if an Error occurs.
+    /// Use [`option_env!`](std::option_env!) to read the generated environment variables.
     skip_if_error: bool,
 }
 

--- a/src/feature/git.rs
+++ b/src/feature/git.rs
@@ -164,6 +164,9 @@ pub struct Git {
     /// The kind of SHA instruction to output.
     #[getset(get = "pub(crate)")]
     sha_kind: ShaKind,
+    /// Enable/Disable skipping [`Git`] if an Error occurs.
+    #[getset(get = "pub(crate)")]
+    skip_if_error: bool,
 }
 
 #[cfg(feature = "git")]
@@ -190,6 +193,7 @@ impl Default for Git {
             semver_dirty: None,
             sha: true,
             sha_kind: ShaKind::Normal,
+            skip_if_error: false,
         }
     }
 }
@@ -231,134 +235,158 @@ pub(crate) fn configure_git<T>(
 where
     T: AsRef<Path>,
 {
-    if let Some(repo_path) = repo_path_opt {
-        let git_config = instructions.git();
-        if git_config.has_enabled() {
-            let repo = Repository::discover(repo_path)?;
-            let ref_head = repo.find_reference("HEAD")?;
-            let repo_path = repo.path().to_path_buf();
+    let repo_path = match repo_path_opt {
+        Some(repo_path) => repo_path,
+        None => return Ok(()),
+    };
 
-            if *git_config.branch() {
-                add_branch_name(&repo, config)?;
-            }
+    let git_config = instructions.git();
 
-            if *git_config.commit_timestamp()
-                || *git_config.sha()
-                || *git_config.commit_author()
-                || *git_config.commit_message()
-            {
-                let commit = ref_head.peel_to_commit()?;
+    let add_entries = || {
+        let repo = Repository::discover(repo_path)?;
+        let ref_head = repo.find_reference("HEAD")?;
+        let repo_path = repo.path().to_path_buf();
 
-                if *git_config.commit_timestamp() {
-                    let commit_time = OffsetDateTime::from_unix_timestamp(commit.time().seconds())?;
-
-                    match git_config.commit_timestamp_timezone() {
-                        crate::TimeZone::Utc => {
-                            add_config_entries(
-                                config,
-                                git_config,
-                                &commit_time.to_offset(UtcOffset::UTC),
-                            )?;
-                        }
-                        #[cfg(feature = "local_offset")]
-                        crate::TimeZone::Local => {
-                            add_config_entries(
-                                config,
-                                git_config,
-                                &commit_time.to_offset(UtcOffset::current_local_offset()?),
-                            )?;
-                        }
-                    }
-                }
-
-                if *git_config.sha() {
-                    match git_config.sha_kind() {
-                        crate::ShaKind::Normal => {
-                            add_entry(
-                                config.cfg_map_mut(),
-                                VergenKey::Sha,
-                                Some(commit.id().to_string()),
-                            );
-                        }
-                        crate::ShaKind::Short => {
-                            let obj = repo.revparse_single("HEAD")?;
-                            add_entry(
-                                config.cfg_map_mut(),
-                                VergenKey::ShortSha,
-                                obj.short_id()?.as_str().map(str::to_string),
-                            );
-                        }
-                        crate::ShaKind::Both => {
-                            add_entry(
-                                config.cfg_map_mut(),
-                                VergenKey::Sha,
-                                Some(commit.id().to_string()),
-                            );
-
-                            let obj = repo.revparse_single("HEAD")?;
-                            add_entry(
-                                config.cfg_map_mut(),
-                                VergenKey::ShortSha,
-                                obj.short_id()?.as_str().map(str::to_string),
-                            );
-                        }
-                    }
-                }
-
-                if *git_config.commit_author() {
-                    add_entry(
-                        config.cfg_map_mut(),
-                        VergenKey::CommitAuthorName,
-                        commit.author().name().map(&str::to_string),
-                    );
-                    add_entry(
-                        config.cfg_map_mut(),
-                        VergenKey::CommitAuthorEmail,
-                        commit.author().email().map(&str::to_string),
-                    );
-                }
-
-                if *git_config.commit_message() {
-                    add_entry(
-                        config.cfg_map_mut(),
-                        VergenKey::CommitMessage,
-                        commit.message().map(&str::to_string),
-                    );
-                }
-            }
-
-            if *git_config.semver() {
-                let dirty = git_config.semver_dirty();
-                match *git_config.semver_kind() {
-                    crate::SemverKind::Normal => {
-                        add_semver(&repo, &DescribeOptions::new(), false, dirty, config);
-                    }
-                    crate::SemverKind::Lightweight => {
-                        let mut opts = DescribeOptions::new();
-                        let _ = opts.describe_tags();
-
-                        add_semver(&repo, &opts, true, dirty, config);
-                    }
-                }
-            }
-
-            if *git_config.commit_count() {
-                add_commit_count(&repo, config);
-            }
-
-            if let Ok(resolved) = ref_head.resolve() {
-                if let Some(name) = resolved.name() {
-                    let path = repo_path.join(name);
-                    // Check whether the path exists in the filesystem before emitting it
-                    if path.exists() {
-                        *config.ref_path_mut() = Some(path);
-                    }
-                }
-            }
-            *config.head_path_mut() = Some(repo_path.join("HEAD"));
+        if *git_config.branch() {
+            add_branch_name(&repo, config)?;
         }
+
+        if *git_config.commit_timestamp()
+            || *git_config.sha()
+            || *git_config.commit_author()
+            || *git_config.commit_message()
+        {
+            let commit = ref_head.peel_to_commit()?;
+
+            if *git_config.commit_timestamp() {
+                let commit_time = OffsetDateTime::from_unix_timestamp(commit.time().seconds())?;
+
+                match git_config.commit_timestamp_timezone() {
+                    crate::TimeZone::Utc => {
+                        add_config_entries(
+                            config,
+                            git_config,
+                            &commit_time.to_offset(UtcOffset::UTC),
+                        )?;
+                    }
+                    #[cfg(feature = "local_offset")]
+                    crate::TimeZone::Local => {
+                        add_config_entries(
+                            config,
+                            git_config,
+                            &commit_time.to_offset(UtcOffset::current_local_offset()?),
+                        )?;
+                    }
+                }
+            }
+
+            if *git_config.sha() {
+                match git_config.sha_kind() {
+                    crate::ShaKind::Normal => {
+                        add_entry(
+                            config.cfg_map_mut(),
+                            VergenKey::Sha,
+                            Some(commit.id().to_string()),
+                        );
+                    }
+                    crate::ShaKind::Short => {
+                        let obj = repo.revparse_single("HEAD")?;
+                        add_entry(
+                            config.cfg_map_mut(),
+                            VergenKey::ShortSha,
+                            obj.short_id()?.as_str().map(str::to_string),
+                        );
+                    }
+                    crate::ShaKind::Both => {
+                        add_entry(
+                            config.cfg_map_mut(),
+                            VergenKey::Sha,
+                            Some(commit.id().to_string()),
+                        );
+
+                        let obj = repo.revparse_single("HEAD")?;
+                        add_entry(
+                            config.cfg_map_mut(),
+                            VergenKey::ShortSha,
+                            obj.short_id()?.as_str().map(str::to_string),
+                        );
+                    }
+                }
+            }
+
+            if *git_config.commit_author() {
+                add_entry(
+                    config.cfg_map_mut(),
+                    VergenKey::CommitAuthorName,
+                    commit.author().name().map(&str::to_string),
+                );
+                add_entry(
+                    config.cfg_map_mut(),
+                    VergenKey::CommitAuthorEmail,
+                    commit.author().email().map(&str::to_string),
+                );
+            }
+
+            if *git_config.commit_message() {
+                add_entry(
+                    config.cfg_map_mut(),
+                    VergenKey::CommitMessage,
+                    commit.message().map(&str::to_string),
+                );
+            }
+        }
+
+        if *git_config.semver() {
+            let dirty = git_config.semver_dirty();
+            match *git_config.semver_kind() {
+                crate::SemverKind::Normal => {
+                    add_semver(&repo, &DescribeOptions::new(), false, dirty, config);
+                }
+                crate::SemverKind::Lightweight => {
+                    let mut opts = DescribeOptions::new();
+                    let _ = opts.describe_tags();
+
+                    add_semver(&repo, &opts, true, dirty, config);
+                }
+            }
+        }
+
+        if *git_config.commit_count() {
+            add_commit_count(&repo, config);
+        }
+
+        if let Ok(resolved) = ref_head.resolve() {
+            if let Some(name) = resolved.name() {
+                let path = repo_path.join(name);
+                // Check whether the path exists in the filesystem before emitting it
+                if path.exists() {
+                    *config.ref_path_mut() = Some(path);
+                }
+            }
+        }
+        *config.head_path_mut() = Some(repo_path.join("HEAD"));
+        Ok(())
+    };
+
+    if git_config.has_enabled() {
+        if git_config.skip_if_error {
+            // hide errors, but emit a warning
+            let result = add_entries();
+            if result.is_err() {
+                let warning = format!(
+                    "An Error occurred during processing of {}. \
+                    VERGEN_{}_* may be incomplete.",
+                    "Git", "GIT"
+                );
+                config.warnings_mut().push(warning);
+            }
+            Ok(())
+        } else {
+            add_entries()
+        }
+    } else {
+        Ok(())
     }
-    Ok(())
 }
 
 #[cfg(feature = "git")]

--- a/src/feature/git.rs
+++ b/src/feature/git.rs
@@ -73,7 +73,7 @@ pub enum ShaKind {
 /// * If the `commit_timestamp` field is false, the date/time instructions will not be generated.
 /// * If the `rerun_on_head_changed` field is false, the `cargo:rerun-if-changed` instructions will not be generated.
 /// * If the `semver` field is false, the `VERGEN_GIT_SEMVER` instruction will not be generated.
-/// * If the `sha` field is fale, the `VERGEN_GIT_SHA` instruction will not be generated.
+/// * If the `sha` field is false, the `VERGEN_GIT_SHA` instruction will not be generated.
 /// * **NOTE** - The SHA defaults to the [`Normal`](ShaKind::Normal) variant, but can be changed via the `sha_kind` field.
 /// * **NOTE** - The [SemVer] defaults to the [`Normal`](SemverKind::Normal) variant, but can be changed via the `semver_kind` field.
 /// * **NOTE** - The [SemVer] is only useful if you have tags on your repository.  If your repository has no tags, this will default to [`CARGO_PKG_VERSION`].
@@ -81,7 +81,7 @@ pub enum ShaKind {
 /// * **NOTE** - The [`Lightweight`](SemverKind::Lightweight) variant will only differ from the [`Normal`](SemverKind::Normal) variant if you use [lightweight] tags in your repository.
 /// * **NOTE** - By default, the date/time related instructions will use [`UTC`](crate::TimeZone::Utc).
 /// * **NOTE** - The date/time instruction output is determined by the [`kind`](crate::TimestampKind) field and can be any combination of the three.
-/// * **NOTE** - If the `rerun_on_head_chaged` instructions are enabled, cargo` will re-run the build script when either `&lt;gitpath&gt;/HEAD` or the file that `&lt;gitpath&gt;/HEAD` points at changes.
+/// * **NOTE** - If the `rerun_on_head_chaged` instructions are enabled, cargo will re-run the build script when either `<gitpath>/HEAD` or the file that `<gitpath>/HEAD` points at changes.
 /// * **NOTE** - Even if a project is developed in a git repository, the repository is not always
 ///     present with the source code, e.g. in a source tarball. By default,
 ///     [`vergen`](crate::vergen) returns an Error in this case. To keep processing other

--- a/src/feature/git.rs
+++ b/src/feature/git.rs
@@ -82,6 +82,10 @@ pub enum ShaKind {
 /// * **NOTE** - By default, the date/time related instructions will use [`UTC`](crate::TimeZone::Utc).
 /// * **NOTE** - The date/time instruction output is determined by the [`kind`](crate::TimestampKind) field and can be any combination of the three.
 /// * **NOTE** - If the `rerun_on_head_chaged` instructions are enabled, cargo` will re-run the build script when either `&lt;gitpath&gt;/HEAD` or the file that `&lt;gitpath&gt;/HEAD` points at changes.
+/// * **NOTE** - Even if a project is developed in a git repository, the repository is not always
+///     present with the source code, e.g. in a source tarball. By default,
+///     [`vergen`](crate::vergen) returns an Error in this case. To keep processing other
+///     sections, set [`Git::skip_if_error`](Git::skip_if_error_mut()) to true.
 ///
 /// # Example
 ///
@@ -165,6 +169,7 @@ pub struct Git {
     #[getset(get = "pub(crate)")]
     sha_kind: ShaKind,
     /// Enable/Disable skipping [`Git`] if an Error occurs.
+    /// Use [`option_env!`](std::option_env!) to read the generated environment variables.
     #[getset(get = "pub(crate)")]
     skip_if_error: bool,
 }

--- a/src/feature/rustc.rs
+++ b/src/feature/rustc.rs
@@ -39,6 +39,8 @@ use {
 /// * If the `sha` field is false, the `VERGEN_RUSTC_COMMIT_HASH` instruction will not be generated.
 /// * **NOTE** - The `commit_date` filed is only a date, as we are restricted to the output from `rustc_version`
 /// * **NOTE** - The `VERGEN_RUSTC_LLVM_VERSION` instruction will only be generated on the `nightly` channel, regardless of the `llvm_version` field.
+/// * **NOTE** - To keep processing other sections if an Error occurs in this one, set
+///     [`Rustc::skip_if_error`](Rustc::skip_if_error_mut()) to true.
 ///
 /// # Example
 ///
@@ -80,6 +82,7 @@ pub struct Rustc {
     /// Enable/Disable the `VERGEN_RUSTC_COMMIT_HASH` instruction
     sha: bool,
     /// Enable/Disable skipping [`Rustc`] if an Error occurs.
+    /// Use [`option_env!`](std::option_env!) to read the generated environment variables.
     skip_if_error: bool,
 }
 

--- a/src/feature/si.rs
+++ b/src/feature/si.rs
@@ -42,6 +42,8 @@ use {
 /// * If the `memory` field is false, the `VERGEN_SYSINFO_TOTAL_MEMORY` instruction will not be generated.
 /// * If the `cpu_vendor` field is false, the `VERGEN_SYSINFO_CPU_VENDOR` instruction will not be generated.
 /// * If the `cpu_core_count` field is false, the `VERGEN_SYSINFO_CPU_CORE_COUNT` instruction will not be generated.
+/// * **NOTE** - To keep processing other sections if an Error occurs in this one, set
+///     [`Sysinfo::skip_if_error`](Sysinfo::skip_if_error_mut()) to true.
 ///
 /// # Example
 ///
@@ -89,6 +91,7 @@ pub struct Sysinfo {
     /// Enable/Disable the `VERGEN_SYSINFO_CPU_FREQUENCY` instruction
     cpu_frequency: bool,
     /// Enable/Disable skipping [`Sysinfo`] if an Error occurs.
+    /// Use [`option_env!`](std::option_env!) to read the generated environment variables.
     skip_if_error: bool,
 }
 

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -105,6 +105,11 @@ where
         writeln!(stdout, "cargo:rerun-if-changed={}", ref_path.display())?;
     }
 
+    // Emit a cargo:warning if a section was skipped over
+    for w in config.warnings() {
+        writeln!(stdout, "cargo:warning={}", w)?;
+    }
+
     Ok(())
 }
 

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -23,6 +23,8 @@ use std::{
 /// * [I/O](std::io::Error) errors may be generated.
 /// * Errors may be generated from the `rustc_version` library.
 /// * [env](std::env::VarError) errors may be generated.
+/// * To ignore Errors generated in a specific section, set `skip_if_error` to true for that
+///   section, e.g. [`Build::skip_if_error`](crate::Build::skip_if_error_mut()).
 ///
 /// # Usage
 ///
@@ -50,6 +52,8 @@ pub fn vergen(config: crate::Config) -> Result<()> {
 /// * [I/O](std::io::Error) errors may be generated.
 /// * Errors may be generated from the `rustc_version` library.
 /// * [env](std::env::VarError) errors may be generated.
+/// * To ignore Errors generated in a specific section, set `skip_if_error` to true for that
+///   section, e.g. [`Build::skip_if_error`](crate::Build::skip_if_error_mut()).
 ///
 /// # Usage
 ///

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -19,7 +19,6 @@ use std::{
 ///
 /// # Errors
 ///
-/// * Errors may be generated from the `git2` library.
 /// * [I/O](std::io::Error) errors may be generated.
 /// * Errors may be generated from the `rustc_version` library.
 /// * [env](std::env::VarError) errors may be generated.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,7 +280,6 @@
         unused_attributes,
         unused_braces,
         unused_comparisons,
-        unused_crate_dependencies,
         unused_doc_comments,
         unused_extern_crates,
         unused_features,


### PR DESCRIPTION
Closes #124 

What has been done:
- Add a configuration option `skip_if_error` to the `build`, `git`, `rustc` and `sysinfo` features, to allow skipping a feature and continuing if an Error occurs. `configure_cargo` is not fallible, so the option wouldn't make sense there. 
- Emit a `cargo:warning` if an Error was skipped in this way.
- Add a test for `skip_if_error` for the `git` feature. This adds a new dependency `tempfile`, which is just needed for this one test of the `git` feature. Sadly, there is no way to define optional dev-dependencies (https://github.com/rust-lang/cargo/issues/1596), so I deactivated the `unused_crate_dependencies` lint.
- Add documentation for the option and mention `option_env!`.
- Fix two unrelated nits. 

Open questions:
-  I'm not sure if `skip_if_error` is a good name, please suggest a better one :)
- It would be nice to add tests for the other features, too. Do you have an idea how to make them Error?
- Is disabling `unused_crate_dependencies` okay for you? 
- If you prefer, I'll open a separate PR for the unrelated nits.
- Please tell me if you'd like the commits squashed :)