### PR TITLE
Prevent E0658 by limiting enum-iterator version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ local_offset = ["time/local-offset"]
 [dependencies]
 anyhow = "1.0.60"
 cfg-if = "1.0.0"
-enum-iterator = "1.1.3"
+enum-iterator = "~1.1.3"
 getset = "0.1.2"
 git2 = { version = "0.14.4", optional = true, default-features = false }
 rustc_version = { version = "0.4.0", optional = true }

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,6 +27,7 @@ impl fmt::Display for ErrKind {
 
 /// An error generated from the `vergen` library
 #[derive(Debug, thiserror::Error)]
+#[allow(variant_size_differences)]
 pub(crate) enum Error {
     /// An error from the `git2` library
     #[cfg(feature = "git")]


### PR DESCRIPTION
Hi!

`enum-iterator` `1.2.0` is using unstable features, causing some projects using vergen to fail when building:
```
error[E0658]: use of unstable library feature 'array_from_fn'
   --> /root/.cargo/registry/src/github.com-1285ae84e5963aae/enum-iterator-1.2.0/src/lib.rs:554:18
    |
554 |             Some(core::array::from_fn(|_| unreachable!()))
    |                  ^^^^^^^^^^^^^^^^^^^^
    |
    = note: see issue #89379 <https://github.com/rust-lang/rust/issues/89379> for more information
```

Thanks!