### PR TITLE
Fix documentation for `SOURCE_DATE_EPOCH` variable

### DIFF
--- a/src/feature/build.rs
+++ b/src/feature/build.rs
@@ -41,7 +41,7 @@ use {
 /// * **NOTE** - To keep processing other sections if an Error occurs in this one, set
 ///     [`Build::skip_if_error`](Build::skip_if_error_mut()) to true.
 /// * **NOTE** - If the
-///     [`SOURCE_BUILD_EPOCH`](https://reproducible-builds.org/docs/source-date-epoch/) environment
+///     [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/docs/source-date-epoch/) environment
 ///     variable is set, vergen will use the value of that variable in place of the current time.
 ///
 /// # Example


### PR DESCRIPTION
There seems to be a typo in the documentation. There isn't such thing as `SOURCE_BUILD_EPOCH`, I think it should be `SOURCE_DATE_EPOCH`.
