### PR TITLE
Fix memory reporting with sysinfo 0.16

### DIFF
--- a/src/feature/si.rs
+++ b/src/feature/si.rs
@@ -301,9 +301,11 @@ fn check_user(_process: &Process, _user: &User) -> bool {
 #[cfg(feature = "si")]
 fn suffix(val: usize) -> &'static str {
     match val {
-        0 => "KB",
-        1 => "MB",
-        2 => "GB",
+        0 => "B",
+        1 => "KB",
+        2 => "MB",
+        3 => "GB",
+        4 => "TB",
         _ => "xB",
     }
 }
@@ -354,10 +356,12 @@ mod test {
 
     #[test]
     fn suffix_works() {
-        assert_eq!("KB", suffix(0));
-        assert_eq!("MB", suffix(1));
-        assert_eq!("GB", suffix(2));
-        assert_eq!("xB", suffix(3));
+        assert_eq!("B", suffix(0));
+        assert_eq!("KB", suffix(1));
+        assert_eq!("MB", suffix(2));
+        assert_eq!("GB", suffix(3));
+        assert_eq!("TB", suffix(4));
+        assert_eq!("xB", suffix(5));
     }
 
     #[test]


### PR DESCRIPTION
With commit 6a2e7545feae37fab052dfe8d5d086827c0d70ab when I run "cargo test --all --all-targets --no-default-features --features build,cargo,si" I see

    cargo:rustc-env=VERGEN_SYSINFO_TOTAL_MEMORY=16 GB

Which correctly reflects the ram in my system. 

However with 2bb2b49d5c0f10fb1a155f5dff3048a392d5ed1c and current master I see.

    cargo:rustc-env=VERGEN_SYSINFO_TOTAL_MEMORY=16 xB

The cause of this is that sysinfo 0.16 changed the units for reporting memory from kilobytes to bytes, this commit updates the reported units to match. I also added TB to the list of possible units. Computers with terabytes of memory do exist nowadays.