### PR TITLE
Bump libgit2 dependency to latest upstream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ anyhow = "1.0.60"
 cfg-if = "1.0.0"
 enum-iterator = "~1.1.3"
 getset = "0.1.2"
-git2 = { version = "0.14.4", optional = true, default-features = false }
+git2 = { version = "0.15.0", optional = true, default-features = false }
 rustc_version = { version = "0.4.0", optional = true }
 sysinfo = { version = "0.27.0", optional = true, default-features = false }
 thiserror = "1.0.32"


### PR DESCRIPTION
Unblocks projects that link against native libgit2 for other reasons
from being able to upgrade.
