### PR TITLE
Add "match" argument to git-describe

### DIFF
--- a/vergen/src/feature/git/cmd.rs
+++ b/vergen/src/feature/git/cmd.rs
@@ -400,7 +400,12 @@ impl EmitBuilder {
     /// Optionally, add the `dirty` or `tags` flag to describe.
     /// See [`git describe`](https://git-scm.com/docs/git-describe#_options) for more details
     ///
-    pub fn git_describe(&mut self, dirty: bool, tags: bool, match_pattern: Option<&'static str>) -> &mut Self {
+    pub fn git_describe(
+        &mut self,
+        dirty: bool,
+        tags: bool,
+        match_pattern: Option<&'static str>,
+    ) -> &mut Self {
         self.git_config.git_describe = true;
         self.git_config.git_describe_dirty = dirty;
         self.git_config.git_describe_tags = tags;

--- a/vergen/tests/git_output.rs
+++ b/vergen/tests/git_output.rs
@@ -326,7 +326,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
         let mut stdout_buf = vec![];
         let failed = EmitBuilder::builder()
             .all_git()
-            .git_describe(true, true)
+            .git_describe(true, true, None)
             .git_sha(true)
             .emit_to_at(&mut stdout_buf, Some(clone_path()))?;
         assert!(!failed);
@@ -343,7 +343,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
         let mut stdout_buf = vec![];
         let failed = EmitBuilder::builder()
             .all_git()
-            .git_describe(true, false)
+            .git_describe(true, false, None)
             .emit_to_at(&mut stdout_buf, Some(clone_path()))?;
         assert!(!failed);
         let output = String::from_utf8_lossy(&stdout_buf);
@@ -358,7 +358,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
         clone_test_repo();
         assert!(EmitBuilder::builder()
             .all_git()
-            .git_describe(true, true)
+            .git_describe(true, true, None)
             .git_sha(true)
             .emit_at(clone_path())
             .is_ok());


### PR DESCRIPTION
As mentioned in https://github.com/rustyhorde/vergen/issues/157, this is just a start and adds it to the `gitcl` implementation, but doesn't handle the other two yet. 