### PR TITLE
Update git command line check to `git --version`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -191,6 +191,7 @@ jobs:
           cargo binstall -V || cargo install cargo-binstall
           rustup override remove
       - name: 💾 Install (tarpaulin, all-features) 💾
+        continue-on-error: true
         run: cargo binstall --no-confirm --no-symlinks cargo-tarpaulin cargo-all-features
       - name: 🧪 Test 🧪
         run: |
@@ -258,6 +259,7 @@ jobs:
           cargo binstall -V || cargo install cargo-binstall
           rustup override remove
       - name: 💾 Install (all-features) 💾
+        continue-on-error: true
         run: cargo binstall --no-confirm --no-symlinks cargo-all-features
       - name: 🧪 Test 🧪
         run: |
@@ -329,6 +331,7 @@ jobs:
           cargo binstall -V || cargo install cargo-binstall
           rustup override remove
       - name: 💾 Install (all-features) 💾
+        continue-on-error: true
         run: cargo binstall --no-confirm --no-symlinks cargo-all-features
       - name: 🧪 Test 🧪
         run: |

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
     "rust-analyzer.cargo.features": [
-        "build","cargo","git","gitoxide","rustc","si","color","serde","trace"
+        "build","cargo","git","gitcl","rustc","si","color","serde","trace"
     ]
 }

--- a/vergen/src/feature/git/cmd.rs
+++ b/vergen/src/feature/git/cmd.rs
@@ -480,25 +480,6 @@ impl EmitBuilder {
         }
     }
 
-    #[cfg(not(test))]
-    pub(crate) fn add_git_map_entries(
-        &self,
-        path: Option<PathBuf>,
-        idempotent: bool,
-        map: &mut RustcEnvMap,
-        warnings: &mut Vec<String>,
-        rerun_if_changed: &mut Vec<String>,
-    ) -> Result<()> {
-        let git_cmd = if let Some(cmd) = self.git_config.git_cmd {
-            cmd
-        } else {
-            "git --version"
-        };
-        check_git(git_cmd).and_then(check_inside_git_worktree)?;
-        self.inner_add_git_map_entries(path, idempotent, map, warnings, rerun_if_changed)
-    }
-
-    #[cfg(test)]
     pub(crate) fn add_git_map_entries(
         &self,
         path: Option<PathBuf>,

--- a/vergen/tests/git_output.rs
+++ b/vergen/tests/git_output.rs
@@ -572,4 +572,22 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
         env::remove_var("VERGEN_GIT_SHA");
         Ok(())
     }
+
+    #[cfg(feature = "gitcl")]
+    #[test]
+    #[serial_test::serial]
+    fn git_cmd_override_works() -> Result<()> {
+        let mut stdout_buf = vec![];
+        let failed = EmitBuilder::builder()
+            .all_git()
+            .git_cmd(Some("git -v"))
+            .emit_to(&mut stdout_buf)?;
+        let output = String::from_utf8_lossy(&stdout_buf);
+        if repo_exists().is_ok() && !failed {
+            assert!(GIT_REGEX_INST.is_match(&output));
+        } else {
+            assert_eq!(ALL_IDEM_OUTPUT, output);
+        }
+        Ok(())
+    }
 }


### PR DESCRIPTION
* By default, `git --version` will be used to check for the existence of git on the command line when using the `gitcl` feature.
* Added the ability to specify the command to use in the git `Config` via the `git_cmd` function

Fixes #175