### PR TITLE
Fix documentation regarding the gitoxide feature

### DIFF
--- a/vergen/src/lib.rs
+++ b/vergen/src/lib.rs
@@ -43,9 +43,9 @@
 //!
 //! [build-dependencies]
 //! # All features enabled
-//! vergen = { version = "8.0.0-beta.0", features = ["build", "cargo", "git", "gitcl", "rustc", "si"] }
+//! vergen = { version = "8.0.0", features = ["build", "cargo", "git", "gitcl", "rustc", "si"] }
 //! # or
-//! vergen = { version = "8.0.0-beta.0", features = ["build", "git", "gitcl"] }
+//! vergen = { version = "8.0.0", features = ["build", "git", "gitcl"] }
 //! # if you wish to disable certain features
 //! ```
 //!
@@ -95,14 +95,14 @@
 //!
 //! | Features | Enables |
 //! | -------- | ------- |
-//! |   gitcl  | `VERGEN_GIT_` instructions emitted via the `git` binary at the command line |
-//! |   git2   | `VERGEN_GIT_` instructions emitted via git `git2` library |
-//! |   gix    | `VERGEN_GIT_` instructions emitted via the `gitoxide` library |
+//! | gitcl    | `VERGEN_GIT_` instructions emitted via the `git` binary at the command line |
+//! | git2     | `VERGEN_GIT_` instructions emitted via git `git2` library |
+//! | gitoxide | `VERGEN_GIT_` instructions emitted via the `gitoxide` library |
 //!
 //! A common configuration would be as follows:
 //! ```toml
 //! [build-dependencies]
-//! vergen = { version = "8.0.0-beta.0", features = [ "build", "git", "gitcl" ]}
+//! vergen = { version = "8.0.0", features = [ "build", "git", "gitcl" ]}
 //! # ...
 //! ```
 //!


### PR DESCRIPTION
* Updated the docs to correctly refer to the `gitoxide` feature.   This was renamed during the beta.
* Updated references to the beta version to the current release version

Fixes #176 