### PR TITLE
Add `--match` support for `git_describe`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
     "rust-analyzer.cargo.features": [
-        "build","cargo","git","gitcl","rustc","si","color","serde","trace"
+        "build","cargo","git","gitoxide","rustc","si","color","serde","trace"
     ]
 }

--- a/vergen/Cargo.toml
+++ b/vergen/Cargo.toml
@@ -14,6 +14,7 @@ version = "8.0.0"
 
 [package.metadata.cargo-all-features]
 denylist = [
+    "git",
     "git2",
     "git2-rs",
     "gitcl",

--- a/vergen/src/feature/git/cmd.rs
+++ b/vergen/src/feature/git/cmd.rs
@@ -456,6 +456,8 @@ impl EmitBuilder {
             warnings.clear();
             rerun_if_changed.clear();
 
+            warnings.push(format!("{e}"));
+            
             if self.git_config.git_branch {
                 add_default_map_entry(VergenKey::GitBranch, map, warnings);
             }

--- a/vergen/src/feature/git/cmd.rs
+++ b/vergen/src/feature/git/cmd.rs
@@ -147,7 +147,7 @@ const SHA: &str = sha!();
 /// # use vergen::EmitBuilder;
 /// #
 /// # fn main() -> Result<()> {
-/// EmitBuilder::builder().git_describe(true, false).emit()?;
+/// EmitBuilder::builder().git_describe(true, false, None).emit()?;
 /// #   Ok(())
 /// # }
 /// ```
@@ -261,7 +261,7 @@ impl EmitBuilder {
             .git_commit_date()
             .git_commit_message()
             .git_commit_timestamp()
-            .git_describe(false, false)
+            .git_describe(false, false, None)
             .git_sha(false)
             .git_cmd(None)
     }
@@ -399,7 +399,12 @@ impl EmitBuilder {
     /// Optionally, add the `dirty` or `tags` flag to describe.
     /// See [`git describe`](https://git-scm.com/docs/git-describe#_options) for more details
     ///
-    pub fn git_describe(&mut self, dirty: bool, tags: bool) -> &mut Self {
+    pub fn git_describe(
+        &mut self,
+        dirty: bool,
+        tags: bool,
+        _match_pattern: Option<&'static str>,
+    ) -> &mut Self {
         self.git_config.git_describe = true;
         self.git_config.git_describe_dirty = dirty;
         self.git_config.git_describe_tags = tags;
@@ -883,7 +888,7 @@ mod test {
     fn git_all_dirty_tags_short() -> Result<()> {
         let config = EmitBuilder::builder()
             .all_git()
-            .git_describe(true, true)
+            .git_describe(true, true, None)
             .git_sha(true)
             .test_emit()?;
         assert_eq!(9, config.cargo_rustc_env_map.len());

--- a/vergen/src/feature/git/cmd.rs
+++ b/vergen/src/feature/git/cmd.rs
@@ -736,7 +736,8 @@ fn add_git_cmd_entry(cmd: &str, key: VergenKey, map: &mut RustcEnvMap) -> Result
             .to_string();
         add_map_entry(key, stdout, map);
     } else {
-        return Err(anyhow!("Failed to run '{cmd}'!"));
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow!("Failed to run '{cmd}'!  {stderr}"));
     }
     Ok(())
 }

--- a/vergen/src/feature/git/cmd.rs
+++ b/vergen/src/feature/git/cmd.rs
@@ -736,8 +736,6 @@ fn add_git_cmd_entry(cmd: &str, key: VergenKey, map: &mut RustcEnvMap) -> Result
             .to_string();
         add_map_entry(key, stdout, map);
     } else {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        eprintln!("{stderr}");
         return Err(anyhow!("Failed to run '{cmd}'!"));
     }
     Ok(())

--- a/vergen/src/feature/git/cmd.rs
+++ b/vergen/src/feature/git/cmd.rs
@@ -926,7 +926,7 @@ mod test {
         let emitter = config.test_emit()?;
         assert_eq!(9, emitter.cargo_rustc_env_map.len());
         assert_eq!(9, count_idempotent(&emitter.cargo_rustc_env_map));
-        assert_eq!(9, emitter.warnings.len());
+        assert_eq!(10, emitter.warnings.len());
         Ok(())
     }
 

--- a/vergen/src/feature/git/cmd.rs
+++ b/vergen/src/feature/git/cmd.rs
@@ -457,7 +457,7 @@ impl EmitBuilder {
             rerun_if_changed.clear();
 
             warnings.push(format!("{e}"));
-            
+
             if self.git_config.git_branch {
                 add_default_map_entry(VergenKey::GitBranch, map, warnings);
             }

--- a/vergen/src/feature/git/git2.rs
+++ b/vergen/src/feature/git/git2.rs
@@ -259,7 +259,7 @@ impl EmitBuilder {
             rerun_if_changed.clear();
 
             warnings.push(format!("{e}"));
-            
+
             if self.git_config.git_branch {
                 add_default_map_entry(VergenKey::GitBranch, map, warnings);
             }

--- a/vergen/src/feature/git/git2.rs
+++ b/vergen/src/feature/git/git2.rs
@@ -682,7 +682,7 @@ mod test {
             assert_eq!(2, config.warnings.len());
         } else {
             assert_eq!(9, count_idempotent(&config.cargo_rustc_env_map));
-            assert_eq!(9, config.warnings.len());
+            assert_eq!(10, config.warnings.len());
         }
         Ok(())
     }
@@ -702,7 +702,7 @@ mod test {
             assert_eq!(2, config.warnings.len());
         } else {
             assert_eq!(9, count_idempotent(&config.cargo_rustc_env_map));
-            assert_eq!(9, config.warnings.len());
+            assert_eq!(10, config.warnings.len());
         }
         Ok(())
     }
@@ -718,7 +718,7 @@ mod test {
             assert_eq!(0, config.warnings.len());
         } else {
             assert_eq!(9, count_idempotent(&config.cargo_rustc_env_map));
-            assert_eq!(9, config.warnings.len());
+            assert_eq!(10, config.warnings.len());
         }
         Ok(())
     }

--- a/vergen/src/feature/git/git2.rs
+++ b/vergen/src/feature/git/git2.rs
@@ -212,7 +212,7 @@ impl EmitBuilder {
     /// cargo:rustc-env=VERGEN_GIT_DESCRIBE=<DESCRIBE>
     /// ```
     ///
-    /// Optionally, add the `dirty` or `tags` flag to describe.
+    /// Optionally, add the `dirty`, `tags`, or `match` flag to describe.
     /// See [`git describe`](https://git-scm.com/docs/git-describe#_options) for more details
     ///
     pub fn git_describe(

--- a/vergen/src/feature/git/git2.rs
+++ b/vergen/src/feature/git/git2.rs
@@ -743,7 +743,7 @@ mod test {
         let emitter = config.test_emit()?;
         assert_eq!(9, emitter.cargo_rustc_env_map.len());
         assert_eq!(9, count_idempotent(&emitter.cargo_rustc_env_map));
-        assert_eq!(9, emitter.warnings.len());
+        assert_eq!(10, emitter.warnings.len());
         Ok(())
     }
 }

--- a/vergen/src/feature/git/git2.rs
+++ b/vergen/src/feature/git/git2.rs
@@ -258,6 +258,8 @@ impl EmitBuilder {
             warnings.clear();
             rerun_if_changed.clear();
 
+            warnings.push(format!("{e}"));
+            
             if self.git_config.git_branch {
                 add_default_map_entry(VergenKey::GitBranch, map, warnings);
             }

--- a/vergen/src/feature/git/gix.rs
+++ b/vergen/src/feature/git/gix.rs
@@ -256,6 +256,8 @@ impl EmitBuilder {
             warnings.clear();
             rerun_if_changed.clear();
 
+            warnings.push(format!("{e}"));
+            
             if self.git_config.git_branch {
                 add_default_map_entry(VergenKey::GitBranch, map, warnings);
             }

--- a/vergen/src/feature/git/gix.rs
+++ b/vergen/src/feature/git/gix.rs
@@ -110,7 +110,7 @@ impl EmitBuilder {
             .git_commit_date()
             .git_commit_message()
             .git_commit_timestamp()
-            .git_describe(false, false)
+            .git_describe(false, false, None)
             .git_sha(false)
     }
 
@@ -214,7 +214,12 @@ impl EmitBuilder {
     /// Optionally, add the `dirty` or `tags` flag to describe.
     /// See [`git describe`](https://git-scm.com/docs/git-describe#_options) for more details
     ///
-    pub fn git_describe(&mut self, dirty: bool, tags: bool) -> &mut Self {
+    pub fn git_describe(
+        &mut self,
+        dirty: bool,
+        tags: bool,
+        _match_pattern: Option<&'static str>,
+    ) -> &mut Self {
         self.git_config.git_describe = true;
         self.git_config.git_describe_dirty = dirty;
         self.git_config.git_describe_tags = tags;

--- a/vergen/src/feature/git/gix.rs
+++ b/vergen/src/feature/git/gix.rs
@@ -257,7 +257,7 @@ impl EmitBuilder {
             rerun_if_changed.clear();
 
             warnings.push(format!("{e}"));
-            
+
             if self.git_config.git_branch {
                 add_default_map_entry(VergenKey::GitBranch, map, warnings);
             }

--- a/vergen/src/feature/git/gix.rs
+++ b/vergen/src/feature/git/gix.rs
@@ -617,7 +617,7 @@ mod test {
         let emitter = config.test_emit()?;
         assert_eq!(9, emitter.cargo_rustc_env_map.len());
         assert_eq!(9, count_idempotent(&emitter.cargo_rustc_env_map));
-        assert_eq!(9, emitter.warnings.len());
+        assert_eq!(10, emitter.warnings.len());
         Ok(())
     }
 }

--- a/vergen/tests/git_output.rs
+++ b/vergen/tests/git_output.rs
@@ -326,7 +326,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
         let mut stdout_buf = vec![];
         let failed = EmitBuilder::builder()
             .all_git()
-            .git_describe(true, true)
+            .git_describe(true, true, None)
             .git_sha(true)
             .emit_to_at(&mut stdout_buf, Some(clone_path()))?;
         assert!(!failed);
@@ -343,7 +343,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
         let mut stdout_buf = vec![];
         let failed = EmitBuilder::builder()
             .all_git()
-            .git_describe(true, false)
+            .git_describe(true, false, None)
             .emit_to_at(&mut stdout_buf, Some(clone_path()))?;
         assert!(!failed);
         let output = String::from_utf8_lossy(&stdout_buf);
@@ -358,7 +358,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
         clone_test_repo();
         assert!(EmitBuilder::builder()
             .all_git()
-            .git_describe(true, true)
+            .git_describe(true, true, None)
             .git_sha(true)
             .emit_at(clone_path())
             .is_ok());

--- a/vergen/tests/git_output.rs
+++ b/vergen/tests/git_output.rs
@@ -85,9 +85,8 @@ mod test_git_git2 {
             .join("\n");
             Regex::new(&re_str).unwrap()
         };
-    }
-
-    const ALL_IDEM_OUTPUT: &str = r#"cargo:rustc-env=VERGEN_GIT_BRANCH=VERGEN_IDEMPOTENT_OUTPUT
+        static ref ALL_IDEM_OUTPUT: Regex = {
+            Regex::new(r#"cargo:rustc-env=VERGEN_GIT_BRANCH=VERGEN_IDEMPOTENT_OUTPUT
 cargo:rustc-env=VERGEN_GIT_COMMIT_AUTHOR_EMAIL=VERGEN_IDEMPOTENT_OUTPUT
 cargo:rustc-env=VERGEN_GIT_COMMIT_AUTHOR_NAME=VERGEN_IDEMPOTENT_OUTPUT
 cargo:rustc-env=VERGEN_GIT_COMMIT_COUNT=VERGEN_IDEMPOTENT_OUTPUT
@@ -96,6 +95,7 @@ cargo:rustc-env=VERGEN_GIT_COMMIT_MESSAGE=VERGEN_IDEMPOTENT_OUTPUT
 cargo:rustc-env=VERGEN_GIT_COMMIT_TIMESTAMP=VERGEN_IDEMPOTENT_OUTPUT
 cargo:rustc-env=VERGEN_GIT_DESCRIBE=VERGEN_IDEMPOTENT_OUTPUT
 cargo:rustc-env=VERGEN_GIT_SHA=VERGEN_IDEMPOTENT_OUTPUT
+cargo:warning=(.*?)
 cargo:warning=VERGEN_GIT_BRANCH set to default
 cargo:warning=VERGEN_GIT_COMMIT_AUTHOR_EMAIL set to default
 cargo:warning=VERGEN_GIT_COMMIT_AUTHOR_NAME set to default
@@ -108,7 +108,9 @@ cargo:warning=VERGEN_GIT_SHA set to default
 cargo:rerun-if-changed=build.rs
 cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT
 cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
-"#;
+"#).unwrap()
+        };
+    }
 
     const IDEM_QUIET_OUTPUT: &str = r#"cargo:rustc-env=VERGEN_GIT_BRANCH=VERGEN_IDEMPOTENT_OUTPUT
 cargo:rustc-env=VERGEN_GIT_COMMIT_AUTHOR_EMAIL=VERGEN_IDEMPOTENT_OUTPUT
@@ -327,7 +329,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
         if repo_exists().is_ok() && !failed {
             assert!(GIT_REGEX_INST.is_match(&output));
         } else {
-            assert_eq!(ALL_IDEM_OUTPUT, output);
+            assert!(ALL_IDEM_OUTPUT.is_match(&output));
         }
         Ok(())
     }
@@ -391,7 +393,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
         if repo_exists().is_ok() && !failed {
             assert!(GIT_REGEX_IDEM_INST.is_match(&output));
         } else {
-            assert_eq!(ALL_IDEM_OUTPUT, output);
+            assert!(ALL_IDEM_OUTPUT.is_match(&output));
         }
         Ok(())
     }
@@ -448,7 +450,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
         if repo_exists().is_ok() && !failed {
             assert!(output.contains("cargo:rustc-env=VERGEN_GIT_BRANCH=this is a bad date"));
         } else {
-            assert_eq!(ALL_IDEM_OUTPUT, output);
+            assert!(ALL_IDEM_OUTPUT.is_match(&output));
         }
         env::remove_var("VERGEN_GIT_BRANCH");
         Ok(())
@@ -465,7 +467,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
             assert!(output
                 .contains("cargo:rustc-env=VERGEN_GIT_COMMIT_AUTHOR_EMAIL=this is a bad date"));
         } else {
-            assert_eq!(ALL_IDEM_OUTPUT, output);
+            assert!(ALL_IDEM_OUTPUT.is_match(&output));
         }
         env::remove_var("VERGEN_GIT_COMMIT_AUTHOR_EMAIL");
         Ok(())
@@ -483,7 +485,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
                 output.contains("cargo:rustc-env=VERGEN_GIT_COMMIT_AUTHOR_NAME=this is a bad date")
             );
         } else {
-            assert_eq!(ALL_IDEM_OUTPUT, output);
+            assert!(ALL_IDEM_OUTPUT.is_match(&output));
         }
         env::remove_var("VERGEN_GIT_COMMIT_AUTHOR_NAME");
         Ok(())
@@ -499,7 +501,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
         if repo_exists().is_ok() && !failed {
             assert!(output.contains("cargo:rustc-env=VERGEN_GIT_COMMIT_COUNT=this is a bad date"));
         } else {
-            assert_eq!(ALL_IDEM_OUTPUT, output);
+            assert!(ALL_IDEM_OUTPUT.is_match(&output));
         }
         env::remove_var("VERGEN_GIT_COMMIT_COUNT");
         Ok(())
@@ -515,7 +517,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
         if repo_exists().is_ok() && !failed {
             assert!(output.contains("cargo:rustc-env=VERGEN_GIT_COMMIT_DATE=this is a bad date"));
         } else {
-            assert_eq!(ALL_IDEM_OUTPUT, output);
+            assert!(ALL_IDEM_OUTPUT.is_match(&output));
         }
         env::remove_var("VERGEN_GIT_COMMIT_DATE");
         Ok(())
@@ -531,7 +533,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
         if repo_exists().is_ok() && !failed {
             assert!(output.contains("cargo:rustc-env=VERGEN_GIT_COMMIT_MESSAGE=this is a bad date"));
         } else {
-            assert_eq!(ALL_IDEM_OUTPUT, output);
+            assert!(ALL_IDEM_OUTPUT.is_match(&output));
         }
         env::remove_var("VERGEN_GIT_COMMIT_MESSAGE");
         Ok(())
@@ -549,7 +551,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
                 output.contains("cargo:rustc-env=VERGEN_GIT_COMMIT_TIMESTAMP=this is a bad date")
             );
         } else {
-            assert_eq!(ALL_IDEM_OUTPUT, output);
+            assert!(ALL_IDEM_OUTPUT.is_match(&output));
         }
         env::remove_var("VERGEN_GIT_COMMIT_TIMESTAMP");
         Ok(())
@@ -565,7 +567,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
         if repo_exists().is_ok() && !failed {
             assert!(output.contains("cargo:rustc-env=VERGEN_GIT_DESCRIBE=this is a bad date"));
         } else {
-            assert_eq!(ALL_IDEM_OUTPUT, output);
+            assert!(ALL_IDEM_OUTPUT.is_match(&output));
         }
         env::remove_var("VERGEN_GIT_DESCRIBE");
         Ok(())
@@ -581,7 +583,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
         if repo_exists().is_ok() && !failed {
             assert!(output.contains("cargo:rustc-env=VERGEN_GIT_SHA=this is a bad date"));
         } else {
-            assert_eq!(ALL_IDEM_OUTPUT, output);
+            assert!(ALL_IDEM_OUTPUT.is_match(&output));
         }
         env::remove_var("VERGEN_GIT_SHA");
         Ok(())

--- a/vergen/tests/git_output.rs
+++ b/vergen/tests/git_output.rs
@@ -86,7 +86,8 @@ mod test_git_git2 {
             Regex::new(&re_str).unwrap()
         };
         static ref ALL_IDEM_OUTPUT: Regex = {
-            Regex::new(r#"cargo:rustc-env=VERGEN_GIT_BRANCH=VERGEN_IDEMPOTENT_OUTPUT
+            Regex::new(
+                r#"cargo:rustc-env=VERGEN_GIT_BRANCH=VERGEN_IDEMPOTENT_OUTPUT
 cargo:rustc-env=VERGEN_GIT_COMMIT_AUTHOR_EMAIL=VERGEN_IDEMPOTENT_OUTPUT
 cargo:rustc-env=VERGEN_GIT_COMMIT_AUTHOR_NAME=VERGEN_IDEMPOTENT_OUTPUT
 cargo:rustc-env=VERGEN_GIT_COMMIT_COUNT=VERGEN_IDEMPOTENT_OUTPUT
@@ -108,7 +109,9 @@ cargo:warning=VERGEN_GIT_SHA set to default
 cargo:rerun-if-changed=build.rs
 cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT
 cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
-"#).unwrap()
+"#,
+            )
+            .unwrap()
         };
     }
 

--- a/vergen/tests/git_output.rs
+++ b/vergen/tests/git_output.rs
@@ -605,7 +605,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
         if repo_exists().is_ok() && !failed {
             assert!(GIT_REGEX_INST.is_match(&output));
         } else {
-            assert_eq!(ALL_IDEM_OUTPUT, output);
+            assert!(ALL_IDEM_OUTPUT.is_match(&output));
         }
         Ok(())
     }

--- a/vergen/tests/git_output.rs
+++ b/vergen/tests/git_output.rs
@@ -304,17 +304,18 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
         Ok(())
     }
 
-    fn curr_shell_fish() -> Result<bool> {
-        let curr_shell = env::var("SHELL")?;
-        Ok(curr_shell.contains("fish"))
+    fn curr_shell_fish() -> bool {
+        env::var("SHELL")
+            .map(|x| x.contains("fish"))
+            .unwrap_or(false)
     }
 
-    fn match_glob() -> Result<Option<&'static str>> {
-        Ok(Some(if curr_shell_fish()? {
+    fn match_glob() -> Option<&'static str> {
+        Some(if curr_shell_fish() {
             "\"0.1*\""
         } else {
             "0.1*"
-        }))
+        })
     }
 
     #[test]
@@ -339,7 +340,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
         let mut stdout_buf = vec![];
         let failed = EmitBuilder::builder()
             .all_git()
-            .git_describe(true, true, match_glob().unwrap_or(None))
+            .git_describe(true, true, match_glob())
             .git_sha(true)
             .emit_to_at(&mut stdout_buf, Some(clone_path()))?;
         assert!(!failed);
@@ -356,7 +357,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
         let mut stdout_buf = vec![];
         let failed = EmitBuilder::builder()
             .all_git()
-            .git_describe(true, false, match_glob().unwrap_or(None))
+            .git_describe(true, false, match_glob())
             .emit_to_at(&mut stdout_buf, Some(clone_path()))?;
         assert!(!failed);
         let output = String::from_utf8_lossy(&stdout_buf);


### PR DESCRIPTION
* Added `--match` support on the `git_describe` function for the `git2` and `gitcl` features (`gitoxide` seems to not support this at the moment)

Closes #157