### PR TITLE
Release 8.1.0

### DIFF
--- a/vergen/Cargo.toml
+++ b/vergen/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 name = "vergen"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "8.0.0"
+version = "8.1.0"
 
 [package.metadata.cargo-all-features]
 denylist = [


### PR DESCRIPTION
* Fixed issue with `gitcl` command line check.  Some versions of git do not recognize the `-v` option.   This was changed to `git --version` by default.   You can also now specify the command you wish to use to check for git in configuration.
* Updated some out of date docs referring to an old feature.
* Added the ability to specify a `match` glob string for the `git describe` output.   This is supported in the `gitcl` and `git2` features.   At this time I could not determine how to do the similar logic with `gitoxide` so this config has no effect in that feature.