### PR TITLE
Added quotes to all match globs.

### DIFF
--- a/vergen/src/feature/git/cmd.rs
+++ b/vergen/src/feature/git/cmd.rs
@@ -577,8 +577,9 @@ impl EmitBuilder {
                     describe_cmd.push_str(" --tags");
                 }
                 if let Some(pattern) = self.git_config.git_describe_match_pattern {
-                    describe_cmd.push_str(" --match ");
+                    describe_cmd.push_str(" --match \"");
                     describe_cmd.push_str(pattern);
+                    describe_cmd.push('\"');
                 }
                 add_git_cmd_entry(&describe_cmd, VergenKey::GitDescribe, map)?;
             }

--- a/vergen/tests/git_output.rs
+++ b/vergen/tests/git_output.rs
@@ -309,20 +309,6 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
         Ok(())
     }
 
-    fn curr_shell_fish() -> bool {
-        env::var("SHELL")
-            .map(|x| x.contains("fish"))
-            .unwrap_or(false)
-    }
-
-    fn match_glob() -> Option<&'static str> {
-        Some(if curr_shell_fish() {
-            "\"0.1*\""
-        } else {
-            "0.1*"
-        })
-    }
-
     #[test]
     #[serial_test::serial]
     fn git_all_output_default_dir() -> Result<()> {
@@ -345,7 +331,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
         let mut stdout_buf = vec![];
         let failed = EmitBuilder::builder()
             .all_git()
-            .git_describe(true, true, match_glob())
+            .git_describe(true, true, Some("0.1*"))
             .git_sha(true)
             .emit_to_at(&mut stdout_buf, Some(clone_path()))?;
         assert!(!failed);
@@ -362,7 +348,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
         let mut stdout_buf = vec![];
         let failed = EmitBuilder::builder()
             .all_git()
-            .git_describe(true, false, match_glob())
+            .git_describe(true, true, Some("0.1*"))
             .emit_to_at(&mut stdout_buf, Some(clone_path()))?;
         assert!(!failed);
         let output = String::from_utf8_lossy(&stdout_buf);


### PR DESCRIPTION
* Added quotes around the `--match` glob pattern.  This should work for all shells.