### PR TITLE
Release 8.1.1

### DIFF
--- a/vergen/Cargo.toml
+++ b/vergen/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 name = "vergen"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "8.1.0"
+version = "8.1.1"
 
 [package.metadata.cargo-all-features]
 denylist = [


### PR DESCRIPTION
* Work with `--match` on `git_describe`
* Updated environment variable overrides to work even if the generation errors.