### PR TITLE
Enumerate usage steps in root crate documentation

### DIFF
--- a/vergen/src/lib.rs
+++ b/vergen/src/lib.rs
@@ -35,7 +35,7 @@
 //! build = "build.rs"
 //! ```
 //!
-//! 1. Add `vergen` as a build dependency in `Cargo.toml`, specifying the features you wish to enable.
+//! 2. Add `vergen` as a build dependency in `Cargo.toml`, specifying the features you wish to enable.
 //!
 //! ```toml
 //! [dependencies]
@@ -49,7 +49,7 @@
 //! # if you wish to disable certain features
 //! ```
 //!
-//! 1. Create a `build.rs` file that uses `vergen` to emit cargo instructions.  Configuration
+//! 3. Create a `build.rs` file that uses `vergen` to emit cargo instructions.  Configuration
 //! starts with [`EmitBuilder`].  Eventually you will call [`emit`](EmitBuilder::emit) to output the
 //! cargo instructions. See the [`emit`](EmitBuilder::emit) documentation for more robust examples.
 //!
@@ -64,7 +64,7 @@
 //! }
 //! ```
 //!
-//! 1. Use the [`env!`](std::env!) macro in your code to read the environment variables.
+//! 4. Use the [`env!`](std::env!) macro in your code to read the environment variables.
 //!
 //! ```compile_fail
 //! println!("Build Timestamp: {}", env!("VERGEN_BUILD_TIMESTAMP"));


### PR DESCRIPTION
Before:

![2023_03_31_firefox_1043_855_kDRMk2gEvZ](https://user-images.githubusercontent.com/5955761/229185435-10b37873-4bd4-4c25-9a32-f0441dafe9b8.png)

After:

![2023_03_31_firefox_1042_848_nORGmVZvSU](https://user-images.githubusercontent.com/5955761/229185227-013dc8dd-d761-4a5f-b3d2-c17b7dc77f73.png)
