### PR TITLE
gix to 0.44.1

### DIFF
--- a/vergen/Cargo.toml
+++ b/vergen/Cargo.toml
@@ -41,7 +41,7 @@ si = ["sysinfo"]
 [dependencies]
 anyhow = "1.0.70"
 git2-rs = { version = "0.17.1", package = "git2", optional = true, default-features = false }
-gix = { version = "0.43.1", optional = true, default-features = false }
+gix = { version = "0.44.1", optional = true, default-features = false }
 rustc_version = { version = "0.4.0", optional = true }
 sysinfo = { version = "0.28.4", optional = true, default-features = false }
 time = { version = "0.3.20", features = [
@@ -53,7 +53,7 @@ time = { version = "0.3.20", features = [
 rustversion = "1.0.12"
 
 [dev-dependencies]
-gix = { version = "0.43.1", default-features = false, features = [
+gix = { version = "0.44.1", default-features = false, features = [
     "blocking-network-client",
 ] }
 lazy_static = "1.4.0"


### PR DESCRIPTION
* Updated `gix` dependency to `0.44.1`.  `0.43.1` and `0.44.0` have been yanked.