### PR TITLE
Fix some minor typos

### DIFF
--- a/vergen/src/emitter.rs
+++ b/vergen/src/emitter.rs
@@ -319,7 +319,7 @@ impl EmitBuilder {
     ///
     /// When this feature is enabled, certain vergen output (i.e. timestamps, sysinfo)
     /// will be set to an idempotent default.  This will allow systems that
-    /// depend on deterministics builds to override user requested `vergen`
+    /// depend on deterministic builds to override user requested `vergen`
     /// impurities.  This will mainly allow for package maintainers to build
     /// packages that depend on `vergen` in a deterministic manner.
     ///
@@ -571,8 +571,8 @@ EmitBuilder::builder()
     #[doc(hidden)]
     /// Emit the cargo build script instructions to the given [`Write`](std::io::Write).
     ///
-    /// **NOTE** - This is genarally only used for testing and probably shouldn't be used
-    /// withing a `build.rs` file.
+    /// **NOTE** - This is generally only used for testing and probably shouldn't be used
+    /// within a `build.rs` file.
     ///
     /// # Errors
     /// * The [`writeln!`](std::writeln!) macro can throw a [`std::io::Error`]
@@ -589,8 +589,8 @@ EmitBuilder::builder()
     /// Emit the cargo build script instructions to the given [`Write`](std::io::Write) at
     /// the given repository path for git instructions
     ///
-    /// **NOTE** - This is genarally only used for testing and probably shouldn't be used
-    /// withing a `build.rs` file.
+    /// **NOTE** - This is generally only used for testing and probably shouldn't be used
+    /// within a `build.rs` file.
     ///
     /// # Errors
     /// * The [`writeln!`](std::writeln!) macro can throw a [`std::io::Error`]

--- a/vergen/src/feature/git/cmd.rs
+++ b/vergen/src/feature/git/cmd.rs
@@ -379,7 +379,7 @@ impl EmitBuilder {
     ///
     /// The value is determined with the following command
     /// ```text
-    #[doc = concat!(commit_message!())]
+    #[doc = concat!(commit_timestamp!())]
     /// ```
     pub fn git_commit_timestamp(&mut self) -> &mut Self {
         self.git_config.git_commit_timestamp = true;

--- a/vergen/src/lib.rs
+++ b/vergen/src/lib.rs
@@ -121,7 +121,7 @@
 //!
 //! ## Goals
 //! I initially wrote `vergen` (**ver**sion **gen**erator, so original) so I could embed a some git information in my
-//! personal projects.  Now, usage has grown to the point that `vergen` need to fit better in the rust ecosystem.
+//! personal projects.  Now, usage has grown to the point that `vergen` needs to fit better in the rust ecosystem.
 //!   
 //! The current goals are as follows:
 //!


### PR DESCRIPTION
The most significant typo in this PR is an incorrect `git` command for the timestamp.