### PR TITLE
Custom build.rs path support, local time offset support, updated gix dep

### DIFF
--- a/vergen/Cargo.toml
+++ b/vergen/Cargo.toml
@@ -41,7 +41,7 @@ si = ["sysinfo"]
 [dependencies]
 anyhow = "1.0.70"
 git2-rs = { version = "0.17.1", package = "git2", optional = true, default-features = false }
-gix = { version = "0.47.0", optional = true, default-features = false }
+gix = { version = "0.48.0", optional = true, default-features = false }
 rustc_version = { version = "0.4.0", optional = true }
 sysinfo = { version = "0.29.0", optional = true, default-features = false }
 time = { version = "0.3.20", features = [
@@ -53,7 +53,7 @@ time = { version = "0.3.20", features = [
 rustversion = "1.0.12"
 
 [dev-dependencies]
-gix = { version = "0.47.0", default-features = false, features = [
+gix = { version = "0.48.0", default-features = false, features = [
     "blocking-network-client",
 ] }
 lazy_static = "1.4.0"

--- a/vergen/Cargo.toml
+++ b/vergen/Cargo.toml
@@ -46,6 +46,7 @@ rustc_version = { version = "0.4.0", optional = true }
 sysinfo = { version = "0.29.0", optional = true, default-features = false }
 time = { version = "0.3.20", features = [
     "formatting",
+    "local-offset",
     "parsing",
 ], optional = true }
 

--- a/vergen/Cargo.toml
+++ b/vergen/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 name = "vergen"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "8.2.2"
+version = "8.2.3"
 
 [package.metadata.cargo-all-features]
 denylist = [

--- a/vergen/src/feature/build.rs
+++ b/vergen/src/feature/build.rs
@@ -15,6 +15,7 @@ use time::{
 pub(crate) struct Config {
     pub(crate) build_date: bool,
     pub(crate) build_timestamp: bool,
+    use_local: bool,
 }
 
 impl Config {
@@ -155,6 +156,12 @@ impl EmitBuilder {
         self
     }
 
+    /// Enable local offset date/timestamp output
+    pub fn use_local_build(&mut self) -> &mut Self {
+        self.build_config.use_local = true;
+        self
+    }
+
     pub(crate) fn add_build_default(
         &self,
         e: Error,
@@ -198,7 +205,13 @@ impl EmitBuilder {
                 true,
                 OffsetDateTime::from_unix_timestamp(i64::from_str(&v)?)?,
             ),
-            Err(std::env::VarError::NotPresent) => (false, OffsetDateTime::now_utc()),
+            Err(std::env::VarError::NotPresent) => {
+                if self.build_config.use_local {
+                    (false, OffsetDateTime::now_local()?)
+                } else {
+                    (false, OffsetDateTime::now_utc())
+                }
+            }
             Err(e) => return Err(e.into()),
         };
 

--- a/vergen/src/feature/git/git2.rs
+++ b/vergen/src/feature/git/git2.rs
@@ -27,7 +27,7 @@ use std::{
 };
 use time::{
     format_description::{self, well_known::Iso8601},
-    OffsetDateTime,
+    OffsetDateTime, UtcOffset,
 };
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -55,6 +55,7 @@ pub(crate) struct Config {
     // git rev-parse HEAD (optionally with --short)
     pub(crate) git_sha: bool,
     git_sha_short: bool,
+    use_local: bool,
     #[cfg(test)]
     fail: bool,
 }
@@ -240,6 +241,12 @@ impl EmitBuilder {
     pub fn git_sha(&mut self, short: bool) -> &mut Self {
         self.git_config.git_sha = true;
         self.git_config.git_sha_short = short;
+        self
+    }
+
+    /// Enable local offset date/timestamp output
+    pub fn use_local_git(&mut self) -> &mut Self {
+        self.git_config.use_local = true;
         self
     }
 
@@ -452,10 +459,16 @@ impl EmitBuilder {
                 true,
                 OffsetDateTime::from_unix_timestamp(i64::from_str(&v)?)?,
             ),
-            Err(std::env::VarError::NotPresent) => (
-                false,
-                OffsetDateTime::from_unix_timestamp(commit.time().seconds())?,
-            ),
+            Err(std::env::VarError::NotPresent) => {
+                let no_offset = OffsetDateTime::from_unix_timestamp(commit.time().seconds())?;
+                if self.git_config.use_local {
+                    let local = UtcOffset::local_offset_at(no_offset)?;
+                    let local_offset = no_offset.checked_to_offset(local).unwrap_or(no_offset);
+                    (false, local_offset)
+                } else {
+                    (false, no_offset)
+                }
+            }
             Err(e) => return Err(e.into()),
         };
 

--- a/vergen/src/feature/git/gix.rs
+++ b/vergen/src/feature/git/gix.rs
@@ -454,7 +454,7 @@ impl EmitBuilder {
             ),
             Err(std::env::VarError::NotPresent) => (
                 false,
-                OffsetDateTime::from_unix_timestamp(commit.time()?.seconds.try_into()?)?,
+                OffsetDateTime::from_unix_timestamp(commit.time()?.seconds)?,
             ),
             Err(e) => return Err(e.into()),
         };

--- a/vergen/tests/build_output.rs
+++ b/vergen/tests/build_output.rs
@@ -32,6 +32,15 @@ cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT
 cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
 "#;
 
+    const IDEM_OUTPUT_CUSTOM_BUILDRS: &str = r#"cargo:rustc-env=VERGEN_BUILD_DATE=VERGEN_IDEMPOTENT_OUTPUT
+cargo:rustc-env=VERGEN_BUILD_TIMESTAMP=VERGEN_IDEMPOTENT_OUTPUT
+cargo:warning=VERGEN_BUILD_DATE set to default
+cargo:warning=VERGEN_BUILD_TIMESTAMP set to default
+cargo:rerun-if-changed=a/custom_build.rs
+cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT
+cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
+"#;
+
     const DISABLED_OUTPUT: &str = r#""#;
 
     const SOURCE_DATE_EPOCH_IDEM_OUTPUT: &str = r#"cargo:rustc-env=VERGEN_BUILD_DATE=2022-12-23
@@ -83,6 +92,20 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
             .emit_to(&mut stdout_buf)?;
         let output = String::from_utf8_lossy(&stdout_buf);
         assert_eq!(IDEM_OUTPUT, output);
+        Ok(())
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn build_all_idempotent_custom_buildrs_output() -> Result<()> {
+        let mut stdout_buf = vec![];
+        EmitBuilder::builder()
+            .idempotent()
+            .custom_build_rs("a/custom_build.rs")
+            .all_build()
+            .emit_to(&mut stdout_buf)?;
+        let output = String::from_utf8_lossy(&stdout_buf);
+        assert_eq!(IDEM_OUTPUT_CUSTOM_BUILDRS, output);
         Ok(())
     }
 

--- a/vergen/tests/build_output.rs
+++ b/vergen/tests/build_output.rs
@@ -71,6 +71,30 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
 
     #[test]
     #[serial_test::serial]
+    fn build_all_output_local() -> Result<()> {
+        let mut stdout_buf = vec![];
+        let result = EmitBuilder::builder()
+            .all_build()
+            .use_local_build()
+            .fail_on_error()
+            .emit_to(&mut stdout_buf);
+        check_local_result(result, &stdout_buf);
+        Ok(())
+    }
+
+    #[cfg(not(target_family = "unix"))]
+    fn check_local_result(result: Result<bool>, stdout_buf: &[u8]) {
+        let output = String::from_utf8_lossy(stdout_buf);
+        assert!(BUILD_REGEX_INST.is_match(&output));
+    }
+
+    #[cfg(target_family = "unix")]
+    fn check_local_result(result: Result<bool>, _stdout_buf: &[u8]) {
+        assert!(result.is_err())
+    }
+
+    #[test]
+    #[serial_test::serial]
     fn build_disabled_output() -> Result<()> {
         let mut stdout_buf = vec![];
         EmitBuilder::builder()

--- a/vergen/tests/build_output.rs
+++ b/vergen/tests/build_output.rs
@@ -82,15 +82,16 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
         Ok(())
     }
 
-    #[cfg(not(target_family = "unix"))]
+    #[cfg(not(target_os = "linux"))]
     fn check_local_result(result: Result<bool>, stdout_buf: &[u8]) {
+        assert!(result.is_ok());
         let output = String::from_utf8_lossy(stdout_buf);
         assert!(BUILD_REGEX_INST.is_match(&output));
     }
 
-    #[cfg(target_family = "unix")]
+    #[cfg(target_os = "linux")]
     fn check_local_result(result: Result<bool>, _stdout_buf: &[u8]) {
-        assert!(result.is_err())
+        assert!(result.is_err());
     }
 
     #[test]

--- a/vergen/tests/git_output.rs
+++ b/vergen/tests/git_output.rs
@@ -363,6 +363,34 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
 
     #[test]
     #[serial_test::serial]
+    fn git_all_flags_test_repo_local() -> Result<()> {
+        create_test_repo();
+        clone_test_repo();
+        let mut stdout_buf = vec![];
+        let result = EmitBuilder::builder()
+            .all_git()
+            .git_describe(true, true, Some("0.1*"))
+            .git_sha(true)
+            .use_local_git()
+            .emit_to_at(&mut stdout_buf, Some(clone_path()));
+        check_local_result(result, &stdout_buf);
+        Ok(())
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn check_local_result(result: Result<bool>, stdout_buf: &[u8]) {
+        assert!(result.is_ok());
+        let output = String::from_utf8_lossy(&stdout_buf);
+        assert!(GIT_REGEX_SHORT_INST.is_match(&output));
+    }
+
+    #[cfg(target_os = "linux")]
+    fn check_local_result(result: Result<bool>, _stdout_buf: &[u8]) {
+        assert!(result.is_err());
+    }
+
+    #[test]
+    #[serial_test::serial]
     fn git_all_output_test_repo() -> Result<()> {
         create_test_repo();
         clone_test_repo();

--- a/vergen/tests/git_output.rs
+++ b/vergen/tests/git_output.rs
@@ -372,6 +372,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
             .git_describe(true, true, Some("0.1*"))
             .git_sha(true)
             .use_local_git()
+            .fail_on_error()
             .emit_to_at(&mut stdout_buf, Some(clone_path()));
         check_local_result(result, &stdout_buf);
         Ok(())

--- a/vergen/tests/git_output.rs
+++ b/vergen/tests/git_output.rs
@@ -381,7 +381,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
     #[cfg(not(target_os = "linux"))]
     fn check_local_result(result: Result<bool>, stdout_buf: &[u8]) {
         assert!(result.is_ok());
-        let output = String::from_utf8_lossy(&stdout_buf);
+        let output = String::from_utf8_lossy(stdout_buf);
         assert!(GIT_REGEX_SHORT_INST.is_match(&output));
     }
 


### PR DESCRIPTION
* Updated `gix` to 0.48.0
* Added support for specifying a custom `build.rs` location.
* Added support for using a local offset for date/timestamp display.  
**NOTE** - Using a local offset will likely cause failures on Unix systems due to the [`Soundness`](
https://docs.rs/time/latest/time/util/local_offset/fn.set_soundness.html#safety) check that the `time` crate performs.  I don't want to introduce unsoundness support to `vergen`.

Fixes #214
Fixes #222 