### PR TITLE
Bump `time` to `0.3.22`

### DIFF
--- a/vergen/Cargo.toml
+++ b/vergen/Cargo.toml
@@ -44,7 +44,7 @@ git2-rs = { version = "0.17.1", package = "git2", optional = true, default-featu
 gix = { version = "0.48.0", optional = true, default-features = false }
 rustc_version = { version = "0.4.0", optional = true }
 sysinfo = { version = "0.29.0", optional = true, default-features = false }
-time = { version = "0.3.20", features = [
+time = { version = "0.3.22", features = [
     "formatting",
     "local-offset",
     "parsing",


### PR DESCRIPTION
As of 022e804, we depend on `OffsetDateTime::checked_to_offset` which was added in `0.3.22`.

Resolves #225 