### PR TITLE
Upgrade git2 crate to 0.18

### DIFF
--- a/vergen/Cargo.toml
+++ b/vergen/Cargo.toml
@@ -40,7 +40,7 @@ si = ["sysinfo"]
 
 [dependencies]
 anyhow = "1.0.72"
-git2-rs = { version = "0.17.2", package = "git2", optional = true, default-features = false }
+git2-rs = { version = "0.18.0", package = "git2", optional = true, default-features = false }
 gix = { version = "0.52.0", optional = true, default-features = false }
 rustc_version = { version = "0.4.0", optional = true }
 sysinfo = { version = "0.29.7", optional = true, default-features = false }


### PR DESCRIPTION
Updates underlying libgit2 from `1.6.4` to `1.7.1`.

See the `git2` crate changelog [here](https://github.com/rust-lang/git2-rs/blob/git2-0.18.0/CHANGELOG.md#0180---2023-08-28).

See the libgit2 changelog [here](https://github.com/libgit2/libgit2/blob/v1.7.1/docs/changelog.md#v171).
