### PR TITLE
update to `gix` 0.53.1

### DIFF
--- a/vergen/Cargo.toml
+++ b/vergen/Cargo.toml
@@ -41,7 +41,7 @@ si = ["sysinfo"]
 [dependencies]
 anyhow = "1.0.72"
 git2-rs = { version = "0.17.2", package = "git2", optional = true, default-features = false }
-gix = { version = "0.52.0", optional = true, default-features = false }
+gix = { version = "0.53.0", optional = true, default-features = false, features = ["revision", "interrupt"] }
 rustc_version = { version = "0.4.0", optional = true }
 sysinfo = { version = "0.29.7", optional = true, default-features = false }
 time = { version = "0.3.23", features = [
@@ -54,7 +54,8 @@ time = { version = "0.3.23", features = [
 rustversion = "1.0.14"
 
 [dev-dependencies]
-gix = { version = "0.52.0", default-features = false, features = [
+gix = { version = "0.53.0", default-features = false, features = [
+    "worktree-mutation",
     "blocking-network-client",
 ] }
 lazy_static = "1.4.0"

--- a/vergen/Cargo.toml
+++ b/vergen/Cargo.toml
@@ -55,6 +55,7 @@ rustversion = "1.0.14"
 
 [dev-dependencies]
 gix = { version = "0.53.0", default-features = false, features = [
+    "interrupt",
     "worktree-mutation",
     "blocking-network-client",
 ] }


### PR DESCRIPTION
It comes with fine-graned features which typically improve compile times
and reduce binary sizes.

Previously, it took 8.3s to build and produced a 3.29MB library, now it take 7.08s
to build and produces a 3.14MB binary.
