### PR TITLE
version bump, remove doc_hidden for emit_at

### DIFF
--- a/vergen/Cargo.toml
+++ b/vergen/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 name = "vergen"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "8.2.4"
+version = "8.2.5"
 
 [package.metadata.cargo-all-features]
 denylist = [

--- a/vergen/src/emitter.rs
+++ b/vergen/src/emitter.rs
@@ -828,7 +828,6 @@ EmitBuilder::builder()
             })
     }
 
-    #[doc(hidden)]
     /// Emit instructions from the given repository path.
     ///
     /// # Errors


### PR DESCRIPTION
* Version to 8.2.5
* Removed `#[doc(hidden)]` from `emit_at` function to allow repository path to be specified (fixes #230)