### PR TITLE
Do not collect disks with `si`

### DIFF
--- a/vergen/src/feature/si.rs
+++ b/vergen/src/feature/si.rs
@@ -501,7 +501,7 @@ fn add_sysinfo_map_entry(
 }
 
 fn setup_system() -> System {
-    let mut system = System::new_all();
+    let mut system = System::new();
     system.refresh_all();
     system
 }


### PR DESCRIPTION
I didn't find anything that might be missing if `System::new()` is used instead of `System::new_all()`.

See [new()](https://docs.rs/sysinfo/latest/sysinfo/trait.SystemExt.html#method.new) vs [new_all()](https://docs.rs/sysinfo/latest/sysinfo/trait.SystemExt.html#method.new_all)

Fix: #266