### PR TITLE
Bump time to avoid issues with nightly builds

### DIFF
--- a/vergen-git2/Cargo.toml
+++ b/vergen-git2/Cargo.toml
@@ -36,7 +36,7 @@ si = ["vergen/si"]
 anyhow = "1.0.79"
 derive_builder = "0.20.0"
 git2-rs = { version = "0.18.0", package = "git2", default-features = false }
-time = { version = "0.3.23", features = [
+time = { version = "0.3.36", features = [
     "formatting",
     "local-offset",
     "parsing",

--- a/vergen-gitcl/Cargo.toml
+++ b/vergen-gitcl/Cargo.toml
@@ -35,7 +35,7 @@ si = ["vergen/si"]
 [dependencies]
 anyhow = "1.0.79"
 derive_builder = "0.20.0"
-time = { version = "0.3.23", features = [
+time = { version = "0.3.36", features = [
     "formatting",
     "local-offset",
     "parsing",

--- a/vergen-gix/Cargo.toml
+++ b/vergen-gix/Cargo.toml
@@ -44,7 +44,7 @@ gix = { version = "0.63.0", default-features = false, features = [
     "revision",
     "interrupt",
 ] }
-time = { version = "0.3.23", features = [
+time = { version = "0.3.36", features = [
     "formatting",
     "local-offset",
     "parsing",

--- a/vergen/Cargo.toml
+++ b/vergen/Cargo.toml
@@ -40,7 +40,7 @@ getset = { version = "0.1.2", optional = true }
 regex = { version = "1.10.3", optional = true }
 rustc_version = { version = "0.4.0", optional = true }
 sysinfo = { version = "0.30.5", optional = true, default-features = false }
-time = { version = "0.3.34", features = [
+time = { version = "0.3.36", features = [
     "formatting",
     "local-offset",
     "parsing",


### PR DESCRIPTION
Rust 1.80 gives an error with time 0.3.34, so updating to the latest (where the issue is fixed). See, e.g., https://github.com/time-rs/time/issues/681

(Maybe one should use workspace dependencies?)