### PR TITLE
Remove getset dependency

### DIFF
--- a/vergen-lib/Cargo.toml
+++ b/vergen-lib/Cargo.toml
@@ -41,7 +41,6 @@ si = []
 [dependencies]
 anyhow = "1.0.86"
 derive_builder = "0.20.0"
-getset = "0.1.2"
 
 [build-dependencies]
 rustversion = "1.0.17"

--- a/vergen-lib/src/emitter.rs
+++ b/vergen-lib/src/emitter.rs
@@ -8,7 +8,6 @@
 
 use crate::{AddCustomEntries, AddEntries, CargoRustcEnvMap, DefaultConfig};
 use anyhow::Result;
-use getset::Getters;
 use std::{
     collections::BTreeMap,
     env,
@@ -17,22 +16,18 @@ use std::{
 
 /// The `Emitter` will emit cargo instructions (i.e. cargo:rustc-env=NAME=VALUE)
 /// base on the configuration you enable.
-#[derive(Clone, Debug, Getters, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Emitter {
     idempotent: bool,
     fail_on_error: bool,
     quiet: bool,
     custom_buildrs: Option<&'static str>,
-    #[getset(get = "pub")]
     #[doc(hidden)]
     cargo_rustc_env_map: CargoRustcEnvMap,
-    #[getset(get = "pub")]
     #[doc(hidden)]
     cargo_rustc_env_map_custom: BTreeMap<String, String>,
-    #[getset(get = "pub")]
     #[doc(hidden)]
     cargo_rerun_if_changed: Vec<String>,
-    #[getset(get = "pub")]
     #[doc(hidden)]
     cargo_warning: Vec<String>,
 }
@@ -44,6 +39,27 @@ impl Default for Emitter {
 }
 
 impl Emitter {
+    #[doc(hidden)]
+    #[inline(always)]
+    pub fn cargo_rustc_env_map(&self) -> &CargoRustcEnvMap {
+        &self.cargo_rustc_env_map
+    }
+    #[doc(hidden)]
+    #[inline(always)]
+    pub fn cargo_rustc_env_map_custom(&self) -> &BTreeMap<String, String> {
+        &self.cargo_rustc_env_map_custom
+    }
+    #[doc(hidden)]
+    #[inline(always)]
+    pub fn cargo_rerun_if_changed(&self) -> &Vec<String> {
+        &self.cargo_rerun_if_changed
+    }
+    #[doc(hidden)]
+    #[inline(always)]
+    pub fn cargo_warning(&self) -> &Vec<String> {
+        &self.cargo_warning
+    }
+
     /// Instantiate the builder to configure the cargo instruction emits
     #[must_use]
     pub fn new() -> Self {

--- a/vergen-lib/src/entries.rs
+++ b/vergen-lib/src/entries.rs
@@ -1,7 +1,6 @@
 use crate::VergenKey;
 
 use anyhow::{Error, Result};
-use getset::Getters;
 use std::collections::BTreeMap;
 
 /// The map used to emit `cargo:rustc-env=NAME=VALUE` cargo instructions
@@ -12,8 +11,7 @@ pub type CargoRerunIfChanged = Vec<String>;
 pub type CargoWarning = Vec<String>;
 
 /// The default configuration to use when an issue has occured generating instructions
-#[derive(Debug, Getters)]
-#[getset(get = "pub")]
+#[derive(Debug)]
 pub struct DefaultConfig {
     /// Should we fail if an error occurs or output idempotent values on error?
     fail_on_error: bool,
@@ -29,6 +27,16 @@ impl DefaultConfig {
             fail_on_error,
             error,
         }
+    }
+    /// Should we fail if an error occurs or output idempotent values on error?
+    #[inline(always)]
+    pub fn fail_on_error(&self) -> &bool {
+        &self.fail_on_error
+    }
+    /// The error that caused us to try default instruction output.
+    #[inline(always)]
+    pub fn error(&self) -> &Error {
+        &self.error
     }
 }
 

--- a/vergen/Cargo.toml
+++ b/vergen/Cargo.toml
@@ -26,7 +26,7 @@ always_include = ["unstable"]
 [features]
 default = []
 build = ["time", "vergen-lib/build"]
-cargo = ["cargo_metadata", "getset", "regex", "vergen-lib/cargo"]
+cargo = ["cargo_metadata", "regex", "vergen-lib/cargo"]
 rustc = ["rustc_version", "vergen-lib/rustc"]
 si = ["sysinfo", "vergen-lib/si"]
 unstable = ["vergen-lib/unstable"]
@@ -36,7 +36,6 @@ emit_and_set = ["vergen-lib/emit_and_set"]
 anyhow = "1.0.86"
 cargo_metadata = { version = "0.18.1", optional = true }
 derive_builder = "0.20.0"
-getset = { version = "0.1.2", optional = true }
 regex = { version = "1.10.5", optional = true }
 rustc_version = { version = "0.4.0", optional = true }
 sysinfo = { version = "0.30.13", optional = true, default-features = false }

--- a/vergen/src/feature/cargo.rs
+++ b/vergen/src/feature/cargo.rs
@@ -9,7 +9,6 @@
 use anyhow::{anyhow, Error, Result};
 use cargo_metadata::{DepKindInfo, DependencyKind, MetadataCommand, Package, PackageId};
 use derive_builder::Builder as DeriveBuilder;
-use getset::Setters;
 use regex::Regex;
 use std::env;
 use vergen_lib::{
@@ -105,7 +104,7 @@ use vergen_lib::{
 /// # }
 /// ```
 ///
-#[derive(Clone, Copy, Debug, DeriveBuilder, PartialEq, Setters)]
+#[derive(Clone, Copy, Debug, DeriveBuilder, PartialEq)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct Cargo {
     /// Emit the DEBUG value set by cargo
@@ -155,7 +154,6 @@ pub struct Cargo {
     /// ```
     ///
     #[builder(default = "None", setter(into))]
-    #[getset(set = "pub")]
     name_filter: Option<&'static str>,
     /// Add a [`DependencyKind`](cargo_metadata::DependencyKind) filter for cargo dependencies
     ///
@@ -164,7 +162,6 @@ pub struct Cargo {
     /// ```
     ///
     #[builder(default = "None", setter(into))]
-    #[getset(set = "pub")]
     dep_kind_filter: Option<DependencyKind>,
 }
 
@@ -265,6 +262,29 @@ impl Cargo {
             .map(|package| format!("{} {}", package.name, package.version))
             .collect();
         Ok(results.join(","))
+    }
+
+    /// Add a name [`Regex`](regex::Regex) filter for cargo dependencies
+    ///
+    /// ```text
+    /// cargo:rustc-env=VERGEN_CARGO_DEPENDENCIES=<deps_filtered_by_name>
+    /// ```
+    ///
+    #[inline(always)]
+    pub fn set_name_filter(&mut self, val: Option<&'static str>) -> &mut Self {
+        self.name_filter = val;
+        self
+    }
+    /// Add a [`DependencyKind`](cargo_metadata::DependencyKind) filter for cargo dependencies
+    ///
+    /// ```text
+    /// cargo:rustc-env=VERGEN_CARGO_DEPENDENCIES=<deps_filtered_by_kind>
+    /// ```
+    ///
+    #[inline(always)]
+    pub fn set_dep_kind_filter(&mut self, val: Option<DependencyKind>) -> &mut Self {
+        self.dep_kind_filter = val;
+        self
     }
 }
 


### PR DESCRIPTION
`getset` is pretty old and pulls in a bit of dependencies, including syn v1 (there is a PR to update to syn v2, but it has not been acted on for a few months). Since it is sparsely used, I simply used `cargo expand` and copied the relevant code.

This should not affect anything other than some reduced dependencies.