### PR TITLE
Consider lightweight tags in `GixBuilder::describe()` based on `tags`

### DIFF
--- a/test_util/src/repo/mod.rs
+++ b/test_util/src/repo/mod.rs
@@ -151,7 +151,7 @@ impl TestRepos {
                 initial_commit_id.into(),
             )?;
 
-            // Tag the previous commit
+            // Create an annotated tag against the first commit
             let _tag_id = committer.tag(
                 "0.1.0",
                 first_commit_id,
@@ -163,13 +163,31 @@ impl TestRepos {
 
             // Create a second commit
             let mut second_tree = Tree::empty();
-            let _second_commit_id = Self::create_commit(
+            let second_commit_id = Self::create_commit(
                 &mut second_tree,
                 &committer,
                 b"Hello, World!",
                 "foo.txt",
                 "such bad casing",
                 first_commit_id.into(),
+            )?;
+
+            // Create a lightweight tag against the second commit
+            let _tag_id = committer.tag_reference(
+                "0.2.0-rc1",
+                second_commit_id,
+                PreviousValue::MustNotExist,
+            )?;
+
+            // Create a third commit
+            let mut third_tree = Tree::empty();
+            let _third_commit_id = Self::create_commit(
+                &mut third_tree,
+                &committer,
+                b"this is my third commit",
+                "foo.txt",
+                "third commit",
+                second_commit_id.into(),
             )?;
         }
 

--- a/vergen-gix/tests/git_output.rs
+++ b/vergen-gix/tests/git_output.rs
@@ -234,6 +234,43 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
 
     #[test]
     #[serial]
+    fn git_all_describe_all_test_repo() -> Result<()> {
+        let repo = TestRepos::new(true, true, false)?;
+        let mut stdout_buf = vec![];
+
+        let mut gix = GixBuilder::default()
+            .all()
+            .describe(false, true, Some("0.1.0")) // Include only annotated tags
+            .build()?;
+        let _ = gix.at_path(repo.path());
+        let failed = Emitter::default()
+            .add_instructions(&gix)?
+            .emit_to(&mut stdout_buf)?;
+        assert!(!failed);
+        let output = String::from_utf8_lossy(&stdout_buf);
+        assert!(GIT_REGEX_INST.is_match(&output));
+        assert!(output.contains("VERGEN_GIT_DESCRIBE=0.1.0"));
+
+        stdout_buf.clear();
+
+        let mut gix = GixBuilder::default()
+            .all()
+            .describe(true, true, Some("0.2.0-rc1")) // Include both annotated and lightweight tags
+            .build()?;
+        let _ = gix.at_path(repo.path());
+        let failed = Emitter::default()
+            .add_instructions(&gix)?
+            .emit_to(&mut stdout_buf)?;
+        assert!(!failed);
+        let output = String::from_utf8_lossy(&stdout_buf);
+        assert!(GIT_REGEX_INST.is_match(&output));
+        assert!(output.contains("VERGEN_GIT_DESCRIBE=0.2.0-rc1"));
+
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
     fn git_emit_at_test_repo() -> Result<()> {
         let repo = TestRepos::new(true, false, false)?;
         let mut gix = GixBuilder::default()


### PR DESCRIPTION
This PR updates the `vergen-gix` crate to consider lightweight tags in a git repository when emitting the describe output, depending on the value of the `tags` parameter provided. This fixes the issue reported in https://github.com/rustyhorde/vergen/issues/359#issuecomment-2262199534. This PR also updates the test repo creation code to create a lightweight tag, and adds a test case in the `vergen-gix` crate.

While working on this PR, I noticed that the `vergen-gix` crate does not consider the `matches` parameter, I've opened #363 so that it's documented for other users of the crate.