### PR TITLE
Use compile-time checked infallible builders

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ members = [
     "vergen-lib",
     "vergen-pretty",
 ]
+
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }

--- a/MIGRATING_v8_to_v9.md
+++ b/MIGRATING_v8_to_v9.md
@@ -21,10 +21,10 @@ use vergen::{
 
 pub fn main() -> Result<()> {
     Emitter::default()
-        .add_instructions(&BuildBuilder::all_build()?)?
-        .add_instructions(&CargoBuilder::all_cargo()?)?
-        .add_instructions(&RustcBuilder::all_rustc()?)?
-        .add_instructions(&SysinfoBuilder::all_sysinfo()?)?
+        .add_instructions(&Build::all_build()?)
+        .add_instructions(&Cargo::all_cargo()?)
+        .add_instructions(&Rustc::all_rustc()?)
+        .add_instructions(&Sysinfo::all_sysinfo()?)
         .emit()
 }
 ```
@@ -54,11 +54,11 @@ use vergen_gix::{
 
 pub fn main() -> Result<()> {
     Emitter::default()
-        .add_instructions(&BuildBuilder::all_build()?)?
-        .add_instructions(&CargoBuilder::all_cargo()?)?
-        .add_instructions(&GixBuilder::all_git()?)?
-        .add_instructions(&RustcBuilder::all_rustc()?)?
-        .add_instructions(&SysinfoBuilder::all_sysinfo()?)?
+        .add_instructions(&Build::all_build()?)
+        .add_instructions(&Cargo::all_cargo()?)
+        .add_instructions(&Gix::all_git()?)
+        .add_instructions(&Rustc::all_rustc()?)
+        .add_instructions(&Sysinfo::all_sysinfo()?)
         .emit()
 }
 ```
@@ -87,11 +87,11 @@ use vergen_gitcl::{
 
 pub fn main() -> Result<()> {
     Emitter::default()
-        .add_instructions(&BuildBuilder::all_build()?)?
-        .add_instructions(&CargoBuilder::all_cargo()?)?
-        .add_instructions(&GitclBuilder::all_git()?)?
-        .add_instructions(&RustcBuilder::all_rustc()?)?
-        .add_instructions(&SysinfoBuilder::all_sysinfo()?)?
+        .add_instructions(&Build::all_build()?)
+        .add_instructions(&Cargo::all_cargo()?)
+        .add_instructions(&Gitcl::all_git()?)
+        .add_instructions(&Rustc::all_rustc()?)
+        .add_instructions(&Sysinfo::all_sysinfo()?)
         .emit()
 }
 ```
@@ -120,11 +120,11 @@ use vergen_git2::{
 
 pub fn main() -> Result<()> {
     Emitter::default()
-        .add_instructions(&BuildBuilder::all_build()?)?
-        .add_instructions(&CargoBuilder::all_cargo()?)?
-        .add_instructions(&Git2Builder::all_git()?)?
-        .add_instructions(&RustcBuilder::all_rustc()?)?
-        .add_instructions(&SysinfoBuilder::all_sysinfo()?)?
+        .add_instructions(&Build::all_build()?)
+        .add_instructions(&Cargo::all_cargo()?)
+        .add_instructions(&Git2::all_git()?)
+        .add_instructions(&Rustc::all_rustc()?)
+        .add_instructions(&Sysinfo::all_sysinfo()?)
         .emit()
 }
 ```

--- a/MIGRATING_v8_to_v9.md
+++ b/MIGRATING_v8_to_v9.md
@@ -21,10 +21,10 @@ use vergen::{
 
 pub fn main() -> Result<()> {
     Emitter::default()
-        .add_instructions(&Build::all_build()?)
-        .add_instructions(&Cargo::all_cargo()?)
-        .add_instructions(&Rustc::all_rustc()?)
-        .add_instructions(&Sysinfo::all_sysinfo()?)
+        .add_instructions(&BuildBuilder::all_build()?)?
+        .add_instructions(&CargoBuilder::all_cargo()?)?
+        .add_instructions(&RustcBuilder::all_rustc()?)?
+        .add_instructions(&SysinfoBuilder::all_sysinfo()?)?
         .emit()
 }
 ```
@@ -54,11 +54,11 @@ use vergen_gix::{
 
 pub fn main() -> Result<()> {
     Emitter::default()
-        .add_instructions(&Build::all_build()?)
-        .add_instructions(&Cargo::all_cargo()?)
-        .add_instructions(&Gix::all_git()?)
-        .add_instructions(&Rustc::all_rustc()?)
-        .add_instructions(&Sysinfo::all_sysinfo()?)
+        .add_instructions(&BuildBuilder::all_build()?)?
+        .add_instructions(&CargoBuilder::all_cargo()?)?
+        .add_instructions(&GixBuilder::all_git()?)?
+        .add_instructions(&RustcBuilder::all_rustc()?)?
+        .add_instructions(&SysinfoBuilder::all_sysinfo()?)?
         .emit()
 }
 ```
@@ -87,11 +87,11 @@ use vergen_gitcl::{
 
 pub fn main() -> Result<()> {
     Emitter::default()
-        .add_instructions(&Build::all_build()?)
-        .add_instructions(&Cargo::all_cargo()?)
-        .add_instructions(&Gitcl::all_git()?)
-        .add_instructions(&Rustc::all_rustc()?)
-        .add_instructions(&Sysinfo::all_sysinfo()?)
+        .add_instructions(&BuildBuilder::all_build()?)?
+        .add_instructions(&CargoBuilder::all_cargo()?)?
+        .add_instructions(&GitclBuilder::all_git()?)?
+        .add_instructions(&RustcBuilder::all_rustc()?)?
+        .add_instructions(&SysinfoBuilder::all_sysinfo()?)?
         .emit()
 }
 ```
@@ -120,11 +120,11 @@ use vergen_git2::{
 
 pub fn main() -> Result<()> {
     Emitter::default()
-        .add_instructions(&Build::all_build()?)
-        .add_instructions(&Cargo::all_cargo()?)
-        .add_instructions(&Git2::all_git()?)
-        .add_instructions(&Rustc::all_rustc()?)
-        .add_instructions(&Sysinfo::all_sysinfo()?)
+        .add_instructions(&BuildBuilder::all_build()?)?
+        .add_instructions(&CargoBuilder::all_cargo()?)?
+        .add_instructions(&Git2Builder::all_git()?)?
+        .add_instructions(&RustcBuilder::all_rustc()?)?
+        .add_instructions(&SysinfoBuilder::all_sysinfo()?)?
         .emit()
 }
 ```

--- a/vergen-git2/Cargo.toml
+++ b/vergen-git2/Cargo.toml
@@ -34,7 +34,7 @@ si = ["vergen/si"]
 
 [dependencies]
 anyhow = "1.0.93"
-derive_builder = "0.20.2"
+bon = "3.3.2"
 git2-rs = { version = "0.20.0", package = "git2", default-features = false }
 time = { version = "0.3.36", features = [
     "formatting",
@@ -57,3 +57,6 @@ test_util = { path = "../test_util", features = ["repo", "unstable"] }
 [package.metadata.docs.rs]
 features = ["build", "cargo", "emit_and_set", "rustc", "si"]
 rustdoc-args = ["--cfg", "docsrs"]
+
+[lints]
+workspace = true

--- a/vergen-git2/src/lib.rs
+++ b/vergen-git2/src/lib.rs
@@ -59,22 +59,22 @@
 //!
 //! ```
 //! # use anyhow::Result;
-//! # use vergen_git2::{Emitter, Git2Builder};
-#![cfg_attr(feature = "build", doc = r"# use vergen_git2::BuildBuilder;")]
-#![cfg_attr(feature = "cargo", doc = r"# use vergen_git2::CargoBuilder;")]
-#![cfg_attr(feature = "rustc", doc = r"# use vergen_git2::RustcBuilder;")]
-#![cfg_attr(feature = "si", doc = r"# use vergen_git2::SysinfoBuilder;")]
+//! # use vergen_git2::{Emitter, Git2};
+#![cfg_attr(feature = "build", doc = r"# use vergen_git2::Build;")]
+#![cfg_attr(feature = "cargo", doc = r"# use vergen_git2::Cargo;")]
+#![cfg_attr(feature = "rustc", doc = r"# use vergen_git2::Rustc;")]
+#![cfg_attr(feature = "si", doc = r"# use vergen_git2::Sysinfo;")]
 #![cfg_attr(feature = "cargo", doc = r"# use test_util::with_cargo_vars;")]
 //! #
 //! # pub fn main() -> Result<()> {
 #![cfg_attr(feature = "cargo", doc = r"# let result = with_cargo_vars(|| {")]
 //! // NOTE: This will output everything, and requires all features enabled.
 //! // NOTE: See the specific builder documentation for configuration options.
-#![cfg_attr(feature = "build", doc = r"let build = BuildBuilder::all_build()?;")]
-#![cfg_attr(feature = "cargo", doc = r"let cargo = CargoBuilder::all_cargo()?;")]
-//! let git2 = Git2Builder::all_git()?;
-#![cfg_attr(feature = "rustc", doc = r"let rustc = RustcBuilder::all_rustc()?;")]
-#![cfg_attr(feature = "si", doc = r"let si = SysinfoBuilder::all_sysinfo()?;")]
+#![cfg_attr(feature = "build", doc = r"let build = Build::all_build();")]
+#![cfg_attr(feature = "cargo", doc = r"let cargo = Cargo::all_cargo();")]
+//! let git2 = Git2::all_git();
+#![cfg_attr(feature = "rustc", doc = r"let rustc = Rustc::all_rustc();")]
+#![cfg_attr(feature = "si", doc = r"let si = Sysinfo::all_sysinfo();")]
 //!
 //! Emitter::default()
 #![cfg_attr(feature = "build", doc = r"    .add_instructions(&build)?")]
@@ -137,11 +137,11 @@
 //!
 //! ```
 //! # use anyhow::Result;
-//! # use vergen_git2::{Emitter, Git2Builder};
-#![cfg_attr(feature = "build", doc = r"# use vergen_git2::BuildBuilder;")]
-#![cfg_attr(feature = "cargo", doc = r"# use vergen_git2::CargoBuilder;")]
-#![cfg_attr(feature = "rustc", doc = r"# use vergen_git2::RustcBuilder;")]
-#![cfg_attr(feature = "si", doc = r"# use vergen_git2::SysinfoBuilder;")]
+//! # use vergen_git2::{Emitter, Git2};
+#![cfg_attr(feature = "build", doc = r"# use vergen_git2::Build;")]
+#![cfg_attr(feature = "cargo", doc = r"# use vergen_git2::Cargo;")]
+#![cfg_attr(feature = "rustc", doc = r"# use vergen_git2::Rustc;")]
+#![cfg_attr(feature = "si", doc = r"# use vergen_git2::Sysinfo;")]
 #![cfg_attr(feature = "cargo", doc = r"# use test_util::with_cargo_vars;")]
 //! #
 //! # pub fn main() -> Result<()> {
@@ -149,21 +149,21 @@
 #![cfg_attr(
     feature = "build",
     doc = r"// NOTE: This will output only the instructions specified.
-// NOTE: See the specific builder documentation for configuration options. 
-let build = BuildBuilder::default().build_timestamp(true).build()?;"
+// NOTE: See the specific builder documentation for configuration options.
+let build = Build::builder().build_timestamp(true).build();"
 )]
 #![cfg_attr(
     feature = "cargo",
-    doc = r"let cargo = CargoBuilder::default().opt_level(true).build()?;"
+    doc = r"let cargo = Cargo::builder().opt_level(true).build();"
 )]
-//! let git2 = Git2Builder::default().commit_timestamp(true).build()?;
+//! let git2 = Git2::builder().commit_timestamp(true).build();
 #![cfg_attr(
     feature = "rustc",
-    doc = r"let rustc = RustcBuilder::default().semver(true).build()?;"
+    doc = r"let rustc = Rustc::builder().semver(true).build();"
 )]
 #![cfg_attr(
     feature = "si",
-    doc = r"let si = SysinfoBuilder::default().cpu_core_count(true).build()?;"
+    doc = r"let si = Sysinfo::builder().cpu_core_count(true).build();"
 )]
 //!
 //! Emitter::default()
@@ -209,7 +209,7 @@ let build = BuildBuilder::default().build_timestamp(true).build()?;"
 //! ```
 //!
 //! ## Features
-//! `vergen-git2` has four main feature toggles allowing you to customize your output. No features are enabled by default.  
+//! `vergen-git2` has four main feature toggles allowing you to customize your output. No features are enabled by default.
 //! You **must** specifically enable the features you wish to use.
 //!
 //! | Feature | Enables |

--- a/vergen-git2/tests/git_output.rs
+++ b/vergen-git2/tests/git_output.rs
@@ -174,7 +174,8 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
     fn git_all_flags_test_repo() -> Result<()> {
         let repo = TestRepos::new(true, false, false)?;
         let mut stdout_buf = vec![];
-        let mut git2 = Git2::all_builder()
+        let mut git2 = Git2::builder()
+            .all()
             .describe(true, false, None)
             .sha(true)
             .build();
@@ -194,7 +195,8 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
     fn git_all_flags_test_repo_local() -> Result<()> {
         let repo = TestRepos::new(true, false, false)?;
         let mut stdout_buf = vec![];
-        let mut git2 = Git2::all_builder()
+        let mut git2 = Git2::builder()
+            .all()
             .describe(true, false, None)
             .sha(true)
             .use_local(true)
@@ -231,7 +233,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
     fn git_all_output_test_repo() -> Result<()> {
         let repo = TestRepos::new(true, true, false)?;
         let mut stdout_buf = vec![];
-        let mut git2 = Git2::all_builder().describe(true, false, None).build();
+        let mut git2 = Git2::builder().all().describe(true, false, None).build();
         let _ = git2.at_path(repo.path());
         let failed = Emitter::default()
             .add_instructions(&git2)?
@@ -247,7 +249,8 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
     fn git_all_describe_all_test_repo() -> Result<()> {
         let repo = TestRepos::new(true, true, false)?;
         let mut stdout_buf = vec![];
-        let mut git2 = Git2::all_builder()
+        let mut git2 = Git2::builder()
+            .all()
             .describe(true, true, Some("0.1.0"))
             .build();
         let _ = git2.at_path(repo.path());
@@ -264,7 +267,8 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
     #[serial]
     fn git_emit_at_test_repo() -> Result<()> {
         let repo = TestRepos::new(true, false, false)?;
-        let mut git2 = Git2::all_builder()
+        let mut git2 = Git2::builder()
+            .all()
             .describe(true, false, None)
             .sha(true)
             .build();

--- a/vergen-git2/tests/git_output.rs
+++ b/vergen-git2/tests/git_output.rs
@@ -6,7 +6,7 @@ mod test_git_git2 {
     use serial_test::serial;
     use std::env::{current_dir, temp_dir};
     use temp_env::with_var;
-    use vergen_git2::{Emitter, Git2Builder};
+    use vergen_git2::{Emitter, Git2};
 
     use test_util::TestRepos;
 
@@ -143,7 +143,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
     #[serial]
     fn git_all_output_idempotent() -> Result<()> {
         let mut stdout_buf = vec![];
-        let mut git2 = Git2Builder::all_git()?;
+        let mut git2 = Git2::all_git();
         let _ = git2.at_path(temp_dir());
         let failed = Emitter::default()
             .add_instructions(&git2)?
@@ -158,7 +158,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
     #[serial]
     fn git_all_output_default_dir() -> Result<()> {
         let mut stdout_buf = vec![];
-        let git2 = Git2Builder::all_git()?;
+        let git2 = Git2::all_git();
         let failed = Emitter::default()
             .add_instructions(&git2)?
             .emit_to(&mut stdout_buf)?;
@@ -174,11 +174,10 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
     fn git_all_flags_test_repo() -> Result<()> {
         let repo = TestRepos::new(true, false, false)?;
         let mut stdout_buf = vec![];
-        let mut git2 = Git2Builder::default()
-            .all()
+        let mut git2 = Git2::all_builder()
             .describe(true, false, None)
             .sha(true)
-            .build()?;
+            .build();
         let _ = git2.at_path(repo.path());
         let failed = Emitter::default()
             .add_instructions(&git2)?
@@ -195,12 +194,11 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
     fn git_all_flags_test_repo_local() -> Result<()> {
         let repo = TestRepos::new(true, false, false)?;
         let mut stdout_buf = vec![];
-        let mut git2 = Git2Builder::default()
-            .all()
+        let mut git2 = Git2::all_builder()
             .describe(true, false, None)
             .sha(true)
             .use_local(true)
-            .build()?;
+            .build();
         let _ = git2.at_path(repo.path());
         let result = || -> Result<bool> {
             let failed = Emitter::default()
@@ -233,10 +231,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
     fn git_all_output_test_repo() -> Result<()> {
         let repo = TestRepos::new(true, true, false)?;
         let mut stdout_buf = vec![];
-        let mut git2 = Git2Builder::default()
-            .all()
-            .describe(true, false, None)
-            .build()?;
+        let mut git2 = Git2::all_builder().describe(true, false, None).build();
         let _ = git2.at_path(repo.path());
         let failed = Emitter::default()
             .add_instructions(&git2)?
@@ -252,10 +247,9 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
     fn git_all_describe_all_test_repo() -> Result<()> {
         let repo = TestRepos::new(true, true, false)?;
         let mut stdout_buf = vec![];
-        let mut git2 = Git2Builder::default()
-            .all()
+        let mut git2 = Git2::all_builder()
             .describe(true, true, Some("0.1.0"))
-            .build()?;
+            .build();
         let _ = git2.at_path(repo.path());
         let failed = Emitter::default()
             .add_instructions(&git2)?
@@ -270,11 +264,10 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
     #[serial]
     fn git_emit_at_test_repo() -> Result<()> {
         let repo = TestRepos::new(true, false, false)?;
-        let mut git2 = Git2Builder::default()
-            .all()
+        let mut git2 = Git2::all_builder()
             .describe(true, false, None)
             .sha(true)
-            .build()?;
+            .build();
         let _ = git2.at_path(repo.path());
         assert!(Emitter::default().add_instructions(&git2)?.emit().is_ok());
         Ok(())
@@ -284,7 +277,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
         use anyhow::Result;
         use serial_test::serial;
         use test_util::TestRepos;
-        use vergen_git2::{Emitter, Git2Builder};
+        use vergen_git2::{Emitter, Git2};
 
         const GIT_DIRTY_TRUE_OUTPUT: &str = r"cargo:rustc-env=VERGEN_GIT_DIRTY=true";
         const GIT_DIRTY_FALSE_OUTPUT: &str = r"cargo:rustc-env=VERGEN_GIT_DIRTY=false";
@@ -306,7 +299,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
             let repo = TestRepos::new(false, false, false)?;
 
             let mut stdout_buf = vec![];
-            let mut git2 = Git2Builder::default().dirty(false).build()?;
+            let mut git2 = Git2::builder().dirty(false).build();
             let _ = git2.at_path(repo.path());
             let _emitter = Emitter::default()
                 .add_instructions(&git2)?
@@ -326,7 +319,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
             let repo = TestRepos::new(false, false, false)?;
 
             let mut stdout_buf = vec![];
-            let mut git2 = Git2Builder::default().dirty(true).build()?;
+            let mut git2 = Git2::builder().dirty(true).build();
             let _ = git2.at_path(repo.path());
             let _emitter = Emitter::default()
                 .add_instructions(&git2)?
@@ -346,7 +339,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
             let repo = TestRepos::new(true, false, false)?;
 
             let mut stdout_buf = vec![];
-            let mut git2 = Git2Builder::default().dirty(false).build()?;
+            let mut git2 = Git2::builder().dirty(false).build();
             let _ = git2.at_path(repo.path());
             let _emitter = Emitter::default()
                 .add_instructions(&git2)?
@@ -366,7 +359,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
             let repo = TestRepos::new(true, false, false)?;
 
             let mut stdout_buf = vec![];
-            let mut git2 = Git2Builder::default().dirty(true).build()?;
+            let mut git2 = Git2::builder().dirty(true).build();
             let _ = git2.at_path(repo.path());
             let _emitter = Emitter::default()
                 .add_instructions(&git2)?
@@ -386,7 +379,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
             let repo = TestRepos::new(false, true, false)?;
 
             let mut stdout_buf = vec![];
-            let mut git2 = Git2Builder::default().dirty(false).build()?;
+            let mut git2 = Git2::builder().dirty(false).build();
             let _ = git2.at_path(repo.path());
             let _emitter = Emitter::default()
                 .add_instructions(&git2)?
@@ -406,7 +399,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
             let repo = TestRepos::new(false, true, false)?;
 
             let mut stdout_buf = vec![];
-            let mut git2 = Git2Builder::default().dirty(true).build()?;
+            let mut git2 = Git2::builder().dirty(true).build();
             let _ = git2.at_path(repo.path());
             let _emitter = Emitter::default()
                 .add_instructions(&git2)?
@@ -426,7 +419,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
             let repo = TestRepos::new(true, true, false)?;
 
             let mut stdout_buf = vec![];
-            let mut git2 = Git2Builder::default().dirty(false).build()?;
+            let mut git2 = Git2::builder().dirty(false).build();
             let _ = git2.at_path(repo.path());
             let _emitter = Emitter::default()
                 .add_instructions(&git2)?
@@ -446,7 +439,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
             let repo = TestRepos::new(true, true, false)?;
 
             let mut stdout_buf = vec![];
-            let mut git2 = Git2Builder::default().dirty(true).build()?;
+            let mut git2 = Git2::builder().dirty(true).build();
             let _ = git2.at_path(repo.path());
             let _emitter = Emitter::default()
                 .add_instructions(&git2)?
@@ -463,7 +456,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
     #[serial]
     fn git_all_idempotent_output() -> Result<()> {
         let mut stdout_buf = vec![];
-        let git2 = Git2Builder::all_git()?;
+        let git2 = Git2::all_git();
         let failed = Emitter::default()
             .idempotent()
             .add_instructions(&git2)?
@@ -479,7 +472,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
     #[serial]
     fn git_all_idempotent_output_quiet() -> Result<()> {
         let mut stdout_buf = vec![];
-        let git2 = Git2Builder::all_git()?;
+        let git2 = Git2::all_git();
         let failed = Emitter::default()
             .idempotent()
             .quiet()
@@ -498,7 +491,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
         with_var("VERGEN_GIT_BRANCH", Some("this is a bad date"), || {
             let result = || -> Result<()> {
                 let mut stdout_buf = vec![];
-                let git2 = Git2Builder::all_git()?;
+                let git2 = Git2::all_git();
                 let _failed = Emitter::default()
                     .add_instructions(&git2)?
                     .emit_to(&mut stdout_buf)?;
@@ -520,7 +513,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
             || {
                 let result = || -> Result<()> {
                     let mut stdout_buf = vec![];
-                    let git2 = Git2Builder::all_git()?;
+                    let git2 = Git2::all_git();
                     let _failed = Emitter::default()
                         .add_instructions(&git2)?
                         .emit_to(&mut stdout_buf)?;
@@ -547,7 +540,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
             || {
                 let result = || -> Result<()> {
                     let mut stdout_buf = vec![];
-                    let git2 = Git2Builder::all_git()?;
+                    let git2 = Git2::all_git();
                     let _failed = Emitter::default()
                         .add_instructions(&git2)?
                         .emit_to(&mut stdout_buf)?;
@@ -574,7 +567,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
             || {
                 let result = || -> Result<()> {
                     let mut stdout_buf = vec![];
-                    let git2 = Git2Builder::all_git()?;
+                    let git2 = Git2::all_git();
                     let _failed = Emitter::default()
                         .add_instructions(&git2)?
                         .emit_to(&mut stdout_buf)?;
@@ -595,7 +588,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
         with_var("VERGEN_GIT_COMMIT_DATE", Some("this is a bad date"), || {
             let result = || -> Result<()> {
                 let mut stdout_buf = vec![];
-                let git2 = Git2Builder::all_git()?;
+                let git2 = Git2::all_git();
                 let _failed = Emitter::default()
                     .add_instructions(&git2)?
                     .emit_to(&mut stdout_buf)?;
@@ -619,7 +612,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
             || {
                 let result = || -> Result<()> {
                     let mut stdout_buf = vec![];
-                    let git2 = Git2Builder::all_git()?;
+                    let git2 = Git2::all_git();
                     let _failed = Emitter::default()
                         .add_instructions(&git2)?
                         .emit_to(&mut stdout_buf)?;
@@ -643,7 +636,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
             || {
                 let result = || -> Result<()> {
                     let mut stdout_buf = vec![];
-                    let git2 = Git2Builder::all_git()?;
+                    let git2 = Git2::all_git();
                     let _failed = Emitter::default()
                         .add_instructions(&git2)?
                         .emit_to(&mut stdout_buf)?;
@@ -665,7 +658,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
         with_var("VERGEN_GIT_DESCRIBE", Some("this is a bad date"), || {
             let result = || -> Result<()> {
                 let mut stdout_buf = vec![];
-                let git2 = Git2Builder::all_git()?;
+                let git2 = Git2::all_git();
                 let _failed = Emitter::default()
                     .add_instructions(&git2)?
                     .emit_to(&mut stdout_buf)?;
@@ -684,7 +677,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
         with_var("VERGEN_GIT_SHA", Some("this is a bad date"), || {
             let result = || -> Result<()> {
                 let mut stdout_buf = vec![];
-                let git2 = Git2Builder::all_git()?;
+                let git2 = Git2::all_git();
                 let _failed = Emitter::default()
                     .add_instructions(&git2)?
                     .emit_to(&mut stdout_buf)?;
@@ -703,7 +696,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
         with_var("VERGEN_GIT_DIRTY", Some("this is a bad date"), || {
             let result = || -> Result<()> {
                 let mut stdout_buf = vec![];
-                let git2 = Git2Builder::all_git()?;
+                let git2 = Git2::all_git();
                 let _failed = Emitter::default()
                     .add_instructions(&git2)?
                     .emit_to(&mut stdout_buf)?;

--- a/vergen-gitcl/Cargo.toml
+++ b/vergen-gitcl/Cargo.toml
@@ -34,7 +34,7 @@ si = ["vergen/si"]
 
 [dependencies]
 anyhow = "1.0.95"
-derive_builder = "0.20.2"
+bon = "3.3.2"
 time = { version = "0.3.37", features = [
     "formatting",
     "local-offset",

--- a/vergen-gitcl/Cargo.toml
+++ b/vergen-gitcl/Cargo.toml
@@ -56,3 +56,6 @@ test_util = { path = "../test_util", features = ["repo", "unstable"] }
 [package.metadata.docs.rs]
 features = ["build", "cargo", "emit_and_set", "rustc", "si"]
 rustdoc-args = ["--cfg", "docsrs"]
+
+[lints]
+workspace = true

--- a/vergen-gitcl/src/lib.rs
+++ b/vergen-gitcl/src/lib.rs
@@ -59,22 +59,22 @@
 //!
 //! ```
 //! # use anyhow::Result;
-//! # use vergen_gitcl::{Emitter, GitclBuilder};
-#![cfg_attr(feature = "build", doc = r"# use vergen_gitcl::BuildBuilder;")]
-#![cfg_attr(feature = "cargo", doc = r"# use vergen_gitcl::CargoBuilder;")]
-#![cfg_attr(feature = "rustc", doc = r"# use vergen_gitcl::RustcBuilder;")]
-#![cfg_attr(feature = "si", doc = r"# use vergen_gitcl::SysinfoBuilder;")]
+//! # use vergen_gitcl::{Emitter, Gitcl};
+#![cfg_attr(feature = "build", doc = r"# use vergen_gitcl::Build;")]
+#![cfg_attr(feature = "cargo", doc = r"# use vergen_gitcl::Cargo;")]
+#![cfg_attr(feature = "rustc", doc = r"# use vergen_gitcl::Rustc;")]
+#![cfg_attr(feature = "si", doc = r"# use vergen_gitcl::Sysinfo;")]
 #![cfg_attr(feature = "cargo", doc = r"# use test_util::with_cargo_vars;")]
 //! #
 //! # pub fn main() -> Result<()> {
 #![cfg_attr(feature = "cargo", doc = r"# let result = with_cargo_vars(|| {")]
 //! // NOTE: This will output everything, and requires all features enabled.
 //! // NOTE: See the specific builder documentation for configuration options.
-#![cfg_attr(feature = "build", doc = r"let build = BuildBuilder::all_build()?;")]
-#![cfg_attr(feature = "cargo", doc = r"let cargo = CargoBuilder::all_cargo()?;")]
-//! let gitcl = GitclBuilder::all_git()?;
-#![cfg_attr(feature = "rustc", doc = r"let rustc = RustcBuilder::all_rustc()?;")]
-#![cfg_attr(feature = "si", doc = r"let si = SysinfoBuilder::all_sysinfo()?;")]
+#![cfg_attr(feature = "build", doc = r"let build = Build::all_build();")]
+#![cfg_attr(feature = "cargo", doc = r"let cargo = Cargo::all_cargo();")]
+//! let gitcl = Gitcl::all_git();
+#![cfg_attr(feature = "rustc", doc = r"let rustc = Rustc::all_rustc();")]
+#![cfg_attr(feature = "si", doc = r"let si = Sysinfo::all_sysinfo();")]
 //!
 //! Emitter::default()
 #![cfg_attr(feature = "build", doc = r"    .add_instructions(&build)?")]
@@ -137,11 +137,11 @@
 //!
 //! ```
 //! # use anyhow::Result;
-//! # use vergen_gitcl::{Emitter, GitclBuilder};
-#![cfg_attr(feature = "build", doc = r"# use vergen_gitcl::BuildBuilder;")]
-#![cfg_attr(feature = "cargo", doc = r"# use vergen_gitcl::CargoBuilder;")]
-#![cfg_attr(feature = "rustc", doc = r"# use vergen_gitcl::RustcBuilder;")]
-#![cfg_attr(feature = "si", doc = r"# use vergen_gitcl::SysinfoBuilder;")]
+//! # use vergen_gitcl::{Emitter, Gitcl};
+#![cfg_attr(feature = "build", doc = r"# use vergen_gitcl::Build;")]
+#![cfg_attr(feature = "cargo", doc = r"# use vergen_gitcl::Cargo;")]
+#![cfg_attr(feature = "rustc", doc = r"# use vergen_gitcl::Rustc;")]
+#![cfg_attr(feature = "si", doc = r"# use vergen_gitcl::Sysinfo;")]
 #![cfg_attr(feature = "cargo", doc = r"# use test_util::with_cargo_vars;")]
 //! #
 //! # pub fn main() -> Result<()> {
@@ -149,21 +149,21 @@
 #![cfg_attr(
     feature = "build",
     doc = r"// NOTE: This will output only the instructions specified.
-// NOTE: See the specific builder documentation for configuration options. 
-let build = BuildBuilder::default().build_timestamp(true).build()?;"
+// NOTE: See the specific builder documentation for configuration options.
+let build = Build::builder().build_timestamp(true).build();"
 )]
 #![cfg_attr(
     feature = "cargo",
-    doc = r"let cargo = CargoBuilder::default().opt_level(true).build()?;"
+    doc = r"let cargo = Cargo::builder().opt_level(true).build();"
 )]
-//! let gitcl = GitclBuilder::default().commit_timestamp(true).build()?;
+//! let gitcl = Gitcl::builder().commit_timestamp(true).build();
 #![cfg_attr(
     feature = "rustc",
-    doc = r"let rustc = RustcBuilder::default().semver(true).build()?;"
+    doc = r"let rustc = Rustc::builder().semver(true).build();"
 )]
 #![cfg_attr(
     feature = "si",
-    doc = r"let si = SysinfoBuilder::default().cpu_core_count(true).build()?;"
+    doc = r"let si = Sysinfo::builder().cpu_core_count(true).build();"
 )]
 //!
 //! Emitter::default()
@@ -209,7 +209,7 @@ let build = BuildBuilder::default().build_timestamp(true).build()?;"
 //! ```
 //!
 //! ## Features
-//! `vergen-gitcl` has four main feature toggles allowing you to customize your output. No features are enabled by default.  
+//! `vergen-gitcl` has four main feature toggles allowing you to customize your output. No features are enabled by default.
 //! You **must** specifically enable the features you wish to use.
 //!
 //! | Feature | Enables |

--- a/vergen-gitcl/tests/git_output.rs
+++ b/vergen-gitcl/tests/git_output.rs
@@ -5,7 +5,7 @@ mod test_git_git2 {
     use serial_test::serial;
     use std::env::temp_dir;
     use temp_env::with_var;
-    use vergen_gitcl::{Emitter, GitclBuilder};
+    use vergen_gitcl::{Emitter, Gitcl};
 
     use test_util::TestRepos;
 
@@ -140,7 +140,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
     #[serial]
     fn git_all_output_idempotent() -> Result<()> {
         let mut stdout_buf = vec![];
-        let mut gitcl = GitclBuilder::all_git()?;
+        let mut gitcl = Gitcl::all_git();
         let _ = gitcl.at_path(temp_dir());
         let failed = Emitter::default()
             .add_instructions(&gitcl)?
@@ -155,7 +155,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
     #[serial]
     fn git_all_output_default_dir() -> Result<()> {
         let mut stdout_buf = vec![];
-        let gitcl = GitclBuilder::all_git()?;
+        let gitcl = Gitcl::all_git();
         let failed = Emitter::default()
             .add_instructions(&gitcl)?
             .emit_to(&mut stdout_buf)?;
@@ -171,11 +171,11 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
     fn git_all_flags_test_repo() -> Result<()> {
         let repo = TestRepos::new(true, false, false)?;
         let mut stdout_buf = vec![];
-        let mut gitcl = GitclBuilder::default()
+        let mut gitcl = Gitcl::builder()
             .all()
             .describe(true, false, None)
             .sha(true)
-            .build()?;
+            .build();
         let _ = gitcl.at_path(repo.path());
         let failed = Emitter::default()
             .add_instructions(&gitcl)?
@@ -191,12 +191,12 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
     fn git_all_flags_test_repo_local() -> Result<()> {
         let repo = TestRepos::new(true, false, false)?;
         let mut stdout_buf = vec![];
-        let mut gitcl = GitclBuilder::default()
+        let mut gitcl = Gitcl::builder()
             .all()
             .describe(true, false, None)
             .sha(true)
             .use_local(true)
-            .build()?;
+            .build();
         let _ = gitcl.at_path(repo.path());
         let result = || -> Result<bool> {
             let failed = Emitter::default()
@@ -229,10 +229,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
     fn git_all_output_test_repo() -> Result<()> {
         let repo = TestRepos::new(true, true, false)?;
         let mut stdout_buf = vec![];
-        let mut gitcl = GitclBuilder::default()
-            .all()
-            .describe(true, false, None)
-            .build()?;
+        let mut gitcl = Gitcl::builder().all().describe(true, false, None).build();
         let _ = gitcl.at_path(repo.path());
         let failed = Emitter::default()
             .add_instructions(&gitcl)?
@@ -248,10 +245,10 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
     fn git_all_describe_all_test_repo() -> Result<()> {
         let repo = TestRepos::new(true, true, false)?;
         let mut stdout_buf = vec![];
-        let mut gitcl = GitclBuilder::default()
+        let mut gitcl = Gitcl::builder()
             .all()
             .describe(true, true, Some("0.1.0"))
-            .build()?;
+            .build();
         let _ = gitcl.at_path(repo.path());
         let failed = Emitter::default()
             .add_instructions(&gitcl)?
@@ -266,11 +263,11 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
     #[serial]
     fn git_emit_at_test_repo() -> Result<()> {
         let repo = TestRepos::new(true, false, false)?;
-        let mut gitcl = GitclBuilder::default()
+        let mut gitcl = Gitcl::builder()
             .all()
             .describe(true, false, None)
             .sha(true)
-            .build()?;
+            .build();
         let _ = gitcl.at_path(repo.path());
         assert!(Emitter::default().add_instructions(&gitcl)?.emit().is_ok());
         Ok(())
@@ -280,7 +277,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
         use anyhow::Result;
         use serial_test::serial;
         use test_util::TestRepos;
-        use vergen_gitcl::{Emitter, GitclBuilder};
+        use vergen_gitcl::{Emitter, Gitcl};
 
         const GIT_DIRTY_TRUE_OUTPUT: &str = r"cargo:rustc-env=VERGEN_GIT_DIRTY=true";
         const GIT_DIRTY_FALSE_OUTPUT: &str = r"cargo:rustc-env=VERGEN_GIT_DIRTY=false";
@@ -302,7 +299,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
             let repo = TestRepos::new(false, false, false)?;
 
             let mut stdout_buf = vec![];
-            let mut gitcl = GitclBuilder::default().dirty(false).build()?;
+            let mut gitcl = Gitcl::builder().dirty(false).build();
             let _ = gitcl.at_path(repo.path());
             let _emitter = Emitter::default()
                 .add_instructions(&gitcl)?
@@ -322,7 +319,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
             let repo = TestRepos::new(false, false, false)?;
 
             let mut stdout_buf = vec![];
-            let mut gitcl = GitclBuilder::default().dirty(true).build()?;
+            let mut gitcl = Gitcl::builder().dirty(true).build();
             let _ = gitcl.at_path(repo.path());
             let _emitter = Emitter::default()
                 .add_instructions(&gitcl)?
@@ -342,7 +339,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
             let repo = TestRepos::new(true, false, false)?;
 
             let mut stdout_buf = vec![];
-            let mut gitcl = GitclBuilder::default().dirty(false).build()?;
+            let mut gitcl = Gitcl::builder().dirty(false).build();
             let _ = gitcl.at_path(repo.path());
             let _emitter = Emitter::default()
                 .add_instructions(&gitcl)?
@@ -362,7 +359,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
             let repo = TestRepos::new(true, false, false)?;
 
             let mut stdout_buf = vec![];
-            let mut gitcl = GitclBuilder::default().dirty(true).build()?;
+            let mut gitcl = Gitcl::builder().dirty(true).build();
             let _ = gitcl.at_path(repo.path());
             let _emitter = Emitter::default()
                 .add_instructions(&gitcl)?
@@ -382,7 +379,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
             let repo = TestRepos::new(false, true, false)?;
 
             let mut stdout_buf = vec![];
-            let mut gitcl = GitclBuilder::default().dirty(false).build()?;
+            let mut gitcl = Gitcl::builder().dirty(false).build();
             let _ = gitcl.at_path(repo.path());
             let _emitter = Emitter::default()
                 .add_instructions(&gitcl)?
@@ -402,7 +399,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
             let repo = TestRepos::new(false, true, false)?;
 
             let mut stdout_buf = vec![];
-            let mut gitcl = GitclBuilder::default().dirty(true).build()?;
+            let mut gitcl = Gitcl::builder().dirty(true).build();
             let _ = gitcl.at_path(repo.path());
             let _emitter = Emitter::default()
                 .add_instructions(&gitcl)?
@@ -422,7 +419,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
             let repo = TestRepos::new(true, true, false)?;
 
             let mut stdout_buf = vec![];
-            let mut gitcl = GitclBuilder::default().dirty(false).build()?;
+            let mut gitcl = Gitcl::builder().dirty(false).build();
             let _ = gitcl.at_path(repo.path());
             let _emitter = Emitter::default()
                 .add_instructions(&gitcl)?
@@ -442,7 +439,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
             let repo = TestRepos::new(true, true, false)?;
 
             let mut stdout_buf = vec![];
-            let mut gitcl = GitclBuilder::default().dirty(true).build()?;
+            let mut gitcl = Gitcl::builder().dirty(true).build();
             let _ = gitcl.at_path(repo.path());
             let _emitter = Emitter::default()
                 .add_instructions(&gitcl)?
@@ -459,7 +456,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
     #[serial]
     fn git_all_idempotent_output() -> Result<()> {
         let mut stdout_buf = vec![];
-        let gitcl = GitclBuilder::all_git()?;
+        let gitcl = Gitcl::all_git();
         let failed = Emitter::default()
             .idempotent()
             .add_instructions(&gitcl)?
@@ -475,7 +472,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
     #[serial]
     fn git_all_idempotent_output_quiet() -> Result<()> {
         let mut stdout_buf = vec![];
-        let gitcl = GitclBuilder::all_git()?;
+        let gitcl = Gitcl::all_git();
         let failed = Emitter::default()
             .idempotent()
             .quiet()
@@ -494,7 +491,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
         with_var("VERGEN_GIT_BRANCH", Some("this is a bad date"), || {
             let result = || -> Result<()> {
                 let mut stdout_buf = vec![];
-                let gitcl = GitclBuilder::all_git()?;
+                let gitcl = Gitcl::all_git();
                 let _failed = Emitter::default()
                     .add_instructions(&gitcl)?
                     .emit_to(&mut stdout_buf)?;
@@ -516,7 +513,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
             || {
                 let result = || -> Result<()> {
                     let mut stdout_buf = vec![];
-                    let gitcl = GitclBuilder::all_git()?;
+                    let gitcl = Gitcl::all_git();
                     let _failed = Emitter::default()
                         .add_instructions(&gitcl)?
                         .emit_to(&mut stdout_buf)?;
@@ -543,7 +540,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
             || {
                 let result = || -> Result<()> {
                     let mut stdout_buf = vec![];
-                    let gitcl = GitclBuilder::all_git()?;
+                    let gitcl = Gitcl::all_git();
                     let _failed = Emitter::default()
                         .add_instructions(&gitcl)?
                         .emit_to(&mut stdout_buf)?;
@@ -570,7 +567,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
             || {
                 let result = || -> Result<()> {
                     let mut stdout_buf = vec![];
-                    let gitcl = GitclBuilder::all_git()?;
+                    let gitcl = Gitcl::all_git();
                     let _failed = Emitter::default()
                         .add_instructions(&gitcl)?
                         .emit_to(&mut stdout_buf)?;
@@ -591,7 +588,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
         with_var("VERGEN_GIT_COMMIT_DATE", Some("this is a bad date"), || {
             let result = || -> Result<()> {
                 let mut stdout_buf = vec![];
-                let gitcl = GitclBuilder::all_git()?;
+                let gitcl = Gitcl::all_git();
                 let _failed = Emitter::default()
                     .add_instructions(&gitcl)?
                     .emit_to(&mut stdout_buf)?;
@@ -615,7 +612,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
             || {
                 let result = || -> Result<()> {
                     let mut stdout_buf = vec![];
-                    let gitcl = GitclBuilder::all_git()?;
+                    let gitcl = Gitcl::all_git();
                     let _failed = Emitter::default()
                         .add_instructions(&gitcl)?
                         .emit_to(&mut stdout_buf)?;
@@ -639,7 +636,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
             || {
                 let result = || -> Result<()> {
                     let mut stdout_buf = vec![];
-                    let gitcl = GitclBuilder::all_git()?;
+                    let gitcl = Gitcl::all_git();
                     let _failed = Emitter::default()
                         .add_instructions(&gitcl)?
                         .emit_to(&mut stdout_buf)?;
@@ -661,7 +658,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
         with_var("VERGEN_GIT_DESCRIBE", Some("this is a bad date"), || {
             let result = || -> Result<()> {
                 let mut stdout_buf = vec![];
-                let gitcl = GitclBuilder::all_git()?;
+                let gitcl = Gitcl::all_git();
                 let _failed = Emitter::default()
                     .add_instructions(&gitcl)?
                     .emit_to(&mut stdout_buf)?;
@@ -680,7 +677,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
         with_var("VERGEN_GIT_SHA", Some("this is a bad date"), || {
             let result = || -> Result<()> {
                 let mut stdout_buf = vec![];
-                let gitcl = GitclBuilder::all_git()?;
+                let gitcl = Gitcl::all_git();
                 let _failed = Emitter::default()
                     .add_instructions(&gitcl)?
                     .emit_to(&mut stdout_buf)?;
@@ -699,7 +696,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
         with_var("VERGEN_GIT_DIRTY", Some("this is a bad date"), || {
             let result = || -> Result<()> {
                 let mut stdout_buf = vec![];
-                let gitcl = GitclBuilder::all_git()?;
+                let gitcl = Gitcl::all_git();
                 let _failed = Emitter::default()
                     .add_instructions(&gitcl)?
                     .emit_to(&mut stdout_buf)?;
@@ -716,7 +713,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
     #[serial]
     fn git_cmd_override_works() -> Result<()> {
         let mut stdout_buf = vec![];
-        let mut gitcl = GitclBuilder::all_git()?;
+        let mut gitcl = Gitcl::all_git();
         let _ = gitcl.git_cmd(Some("git -v"));
         let failed = Emitter::default()
             .add_instructions(&gitcl)?

--- a/vergen-gix/Cargo.toml
+++ b/vergen-gix/Cargo.toml
@@ -65,3 +65,6 @@ temp-env = "0.3.6"
 [package.metadata.docs.rs]
 features = ["build", "cargo", "emit_and_set", "rustc", "si"]
 rustdoc-args = ["--cfg", "docsrs"]
+
+[lints]
+workspace = true

--- a/vergen-gix/Cargo.toml
+++ b/vergen-gix/Cargo.toml
@@ -39,7 +39,7 @@ si = ["vergen/si"]
 
 [dependencies]
 anyhow = "1.0.95"
-derive_builder = "0.20.2"
+bon = "3.3.2"
 gix = { version = "0.69.1", default-features = false, features = [
     "revision",
     "interrupt",

--- a/vergen-gix/src/lib.rs
+++ b/vergen-gix/src/lib.rs
@@ -59,22 +59,22 @@
 //!
 //! ```
 //! # use anyhow::Result;
-//! # use vergen_gix::{Emitter, GixBuilder};
-#![cfg_attr(feature = "build", doc = r"# use vergen_gix::BuildBuilder;")]
-#![cfg_attr(feature = "cargo", doc = r"# use vergen_gix::CargoBuilder;")]
-#![cfg_attr(feature = "rustc", doc = r"# use vergen_gix::RustcBuilder;")]
-#![cfg_attr(feature = "si", doc = r"# use vergen_gix::SysinfoBuilder;")]
+//! # use vergen_gix::{Emitter, Gix};
+#![cfg_attr(feature = "build", doc = r"# use vergen_gix::Build;")]
+#![cfg_attr(feature = "cargo", doc = r"# use vergen_gix::Cargo;")]
+#![cfg_attr(feature = "rustc", doc = r"# use vergen_gix::Rustc;")]
+#![cfg_attr(feature = "si", doc = r"# use vergen_gix::Sysinfo;")]
 #![cfg_attr(feature = "cargo", doc = r"# use test_util::with_cargo_vars;")]
 //! #
 //! # pub fn main() -> Result<()> {
 #![cfg_attr(feature = "cargo", doc = r"# let result = with_cargo_vars(|| {")]
 //! // NOTE: This will output everything, and requires all features enabled.
 //! // NOTE: See the specific builder documentation for configuration options.
-#![cfg_attr(feature = "build", doc = r"let build = BuildBuilder::all_build()?;")]
-#![cfg_attr(feature = "cargo", doc = r"let cargo = CargoBuilder::all_cargo()?;")]
-//! let gitcl = GixBuilder::all_git()?;
-#![cfg_attr(feature = "rustc", doc = r"let rustc = RustcBuilder::all_rustc()?;")]
-#![cfg_attr(feature = "si", doc = r"let si = SysinfoBuilder::all_sysinfo()?;")]
+#![cfg_attr(feature = "build", doc = r"let build = Build::all_build();")]
+#![cfg_attr(feature = "cargo", doc = r"let cargo = Cargo::all_cargo();")]
+//! let gitcl = Gix::all_git();
+#![cfg_attr(feature = "rustc", doc = r"let rustc = Rustc::all_rustc();")]
+#![cfg_attr(feature = "si", doc = r"let si = Sysinfo::all_sysinfo();")]
 //!
 //! Emitter::default()
 #![cfg_attr(feature = "build", doc = r"    .add_instructions(&build)?")]
@@ -138,10 +138,10 @@
 //! ```
 //! # use anyhow::Result;
 //! # use vergen_gix::{Emitter, GixBuilder};
-#![cfg_attr(feature = "build", doc = r"# use vergen_gix::BuildBuilder;")]
-#![cfg_attr(feature = "cargo", doc = r"# use vergen_gix::CargoBuilder;")]
-#![cfg_attr(feature = "rustc", doc = r"# use vergen_gix::RustcBuilder;")]
-#![cfg_attr(feature = "si", doc = r"# use vergen_gix::SysinfoBuilder;")]
+#![cfg_attr(feature = "build", doc = r"# use vergen_gix::Build;")]
+#![cfg_attr(feature = "cargo", doc = r"# use vergen_gix::Cargo;")]
+#![cfg_attr(feature = "rustc", doc = r"# use vergen_gix::Rustc;")]
+#![cfg_attr(feature = "si", doc = r"# use vergen_gix::Sysinfo;")]
 #![cfg_attr(feature = "cargo", doc = r"# use test_util::with_cargo_vars;")]
 //! #
 //! # pub fn main() -> Result<()> {
@@ -149,21 +149,21 @@
 #![cfg_attr(
     feature = "build",
     doc = r"// NOTE: This will output only the instructions specified.
-// NOTE: See the specific builder documentation for configuration options. 
-let build = BuildBuilder::default().build_timestamp(true).build()?;"
+// NOTE: See the specific builder documentation for configuration options.
+let build = Build::builder().build_timestamp(true).build();"
 )]
 #![cfg_attr(
     feature = "cargo",
-    doc = r"let cargo = CargoBuilder::default().opt_level(true).build()?;"
+    doc = r"let cargo = Cargo::builder().opt_level(true).build();"
 )]
-//! let gitcl = GixBuilder::default().commit_timestamp(true).build()?;
+//! let gitcl = Gix::builder().commit_timestamp(true).build();
 #![cfg_attr(
     feature = "rustc",
-    doc = r"let rustc = RustcBuilder::default().semver(true).build()?;"
+    doc = r"let rustc = Rustc::builder().semver(true).build();"
 )]
 #![cfg_attr(
     feature = "si",
-    doc = r"let si = SysinfoBuilder::default().cpu_core_count(true).build()?;"
+    doc = r"let si = Sysinfo::builder().cpu_core_count(true).build();"
 )]
 //!
 //! Emitter::default()
@@ -209,7 +209,7 @@ let build = BuildBuilder::default().build_timestamp(true).build()?;"
 //! ```
 //!
 //! ## Features
-//! `vergen-gix` has four main feature toggles allowing you to customize your output. No features are enabled by default.  
+//! `vergen-gix` has four main feature toggles allowing you to customize your output. No features are enabled by default.
 //! You **must** specifically enable the features you wish to use.
 //!
 //! | Feature | Enables |
@@ -459,9 +459,9 @@ mod gix;
 pub use crate::gix::Gix;
 pub use crate::gix::GixBuilder;
 #[cfg(feature = "build")]
-pub use vergen::BuildBuilder;
+pub use vergen::{Build, BuildBuilder};
 #[cfg(feature = "cargo")]
-pub use vergen::CargoBuilder;
+pub use vergen::{Cargo, CargoBuilder};
 #[cfg(feature = "si")]
 pub use vergen::CpuRefreshKind;
 #[cfg(feature = "cargo")]
@@ -473,9 +473,9 @@ pub use vergen::ProcessRefreshKind;
 #[cfg(feature = "si")]
 pub use vergen::RefreshKind;
 #[cfg(feature = "rustc")]
-pub use vergen::RustcBuilder;
+pub use vergen::{Rustc, RustcBuilder};
 #[cfg(feature = "si")]
-pub use vergen::SysinfoBuilder;
+pub use vergen::{Sysinfo, SysinfoBuilder};
 pub use vergen_lib::AddCustomEntries;
 pub use vergen_lib::CargoRerunIfChanged;
 pub use vergen_lib::CargoWarning;

--- a/vergen-gix/tests/git_output.rs
+++ b/vergen-gix/tests/git_output.rs
@@ -6,7 +6,7 @@ mod test_git_gix {
     use std::env::{self, temp_dir};
     use temp_env::with_var;
     use vergen::Emitter;
-    use vergen_gix::GixBuilder;
+    use vergen_gix::Gix;
 
     use test_util::TestRepos;
 
@@ -134,7 +134,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
     #[serial]
     fn git_all_output_idempotent() -> Result<()> {
         let mut stdout_buf = vec![];
-        let mut gix = GixBuilder::all_git()?;
+        let mut gix = Gix::all_git();
         let _ = gix.at_path(temp_dir());
         let failed = Emitter::default()
             .add_instructions(&gix)?
@@ -149,7 +149,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
     #[serial]
     fn git_all_output_default_dir() -> Result<()> {
         let mut stdout_buf = vec![];
-        let gix = GixBuilder::all_git()?;
+        let gix = Gix::all_git();
         let failed = Emitter::default()
             .add_instructions(&gix)?
             .emit_to(&mut stdout_buf)?;
@@ -165,11 +165,11 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
     fn git_all_flags_test_repo() -> Result<()> {
         let repo = TestRepos::new(true, false, false)?;
         let mut stdout_buf = vec![];
-        let mut gix = GixBuilder::default()
+        let mut gix = Gix::builder()
             .all()
             .describe(true, false, None)
             .sha(true)
-            .build()?;
+            .build();
         let _ = gix.at_path(repo.path());
         let failed = Emitter::default()
             .add_instructions(&gix)?
@@ -185,12 +185,12 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
     fn git_all_flags_test_repo_local() -> Result<()> {
         let repo = TestRepos::new(true, false, false)?;
         let mut stdout_buf = vec![];
-        let mut gix = GixBuilder::default()
+        let mut gix = Gix::builder()
             .all()
             .describe(true, false, None)
             .sha(true)
             .use_local(true)
-            .build()?;
+            .build();
         let _ = gix.at_path(repo.path());
         let result = || -> Result<bool> {
             let failed = Emitter::default()
@@ -223,7 +223,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
     fn git_all_output_test_repo() -> Result<()> {
         let repo = TestRepos::new(true, true, false)?;
         let mut stdout_buf = vec![];
-        let mut gix = GixBuilder::all_git()?;
+        let mut gix = Gix::all_git();
         let _ = gix.at_path(repo.path());
         let failed = Emitter::default()
             .add_instructions(&gix)?
@@ -240,10 +240,10 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
         let repo = TestRepos::new(true, true, false)?;
         let mut stdout_buf = vec![];
 
-        let mut gix = GixBuilder::default()
+        let mut gix = Gix::builder()
             .all()
             .describe(false, true, Some("0.1.0")) // Include only annotated tags
-            .build()?;
+            .build();
         let _ = gix.at_path(repo.path());
         let failed = Emitter::default()
             .add_instructions(&gix)?
@@ -255,10 +255,10 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
 
         stdout_buf.clear();
 
-        let mut gix = GixBuilder::default()
+        let mut gix = Gix::builder()
             .all()
             .describe(true, true, Some("0.2.0-rc1")) // Include both annotated and lightweight tags
-            .build()?;
+            .build();
         let _ = gix.at_path(repo.path());
         let failed = Emitter::default()
             .add_instructions(&gix)?
@@ -275,11 +275,11 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
     #[serial]
     fn git_emit_at_test_repo() -> Result<()> {
         let repo = TestRepos::new(true, false, false)?;
-        let mut gix = GixBuilder::default()
+        let mut gix = Gix::builder()
             .all()
             .describe(true, false, None)
             .sha(true)
-            .build()?;
+            .build();
         let _ = gix.at_path(repo.path());
         assert!(Emitter::default().add_instructions(&gix)?.emit().is_ok());
         Ok(())
@@ -289,7 +289,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
     #[serial]
     fn git_all_idempotent_output() -> Result<()> {
         let mut stdout_buf = vec![];
-        let gix = GixBuilder::all_git()?;
+        let gix = Gix::all_git();
         let failed = Emitter::default()
             .idempotent()
             .add_instructions(&gix)?
@@ -305,7 +305,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
     #[serial_test::serial]
     fn git_all_idempotent_output_quiet() -> Result<()> {
         let mut stdout_buf = vec![];
-        let gix = GixBuilder::all_git()?;
+        let gix = Gix::all_git();
         let failed = Emitter::default()
             .idempotent()
             .quiet()
@@ -324,7 +324,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
         with_var("VERGEN_GIT_BRANCH", Some("this is a bad date"), || {
             let result = || -> Result<()> {
                 let mut stdout_buf = vec![];
-                let gix = GixBuilder::all_git()?;
+                let gix = Gix::all_git();
                 let _failed = Emitter::default()
                     .add_instructions(&gix)?
                     .emit_to(&mut stdout_buf)?;
@@ -346,7 +346,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
             || {
                 let result = || -> Result<()> {
                     let mut stdout_buf = vec![];
-                    let gix = GixBuilder::all_git()?;
+                    let gix = Gix::all_git();
                     let _failed = Emitter::default()
                         .add_instructions(&gix)?
                         .emit_to(&mut stdout_buf)?;
@@ -373,7 +373,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
             || {
                 let result = || -> Result<()> {
                     let mut stdout_buf = vec![];
-                    let gix = GixBuilder::all_git()?;
+                    let gix = Gix::all_git();
                     let _failed = Emitter::default()
                         .add_instructions(&gix)?
                         .emit_to(&mut stdout_buf)?;
@@ -400,7 +400,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
             || {
                 let result = || -> Result<()> {
                     let mut stdout_buf = vec![];
-                    let gix = GixBuilder::all_git()?;
+                    let gix = Gix::all_git();
                     let _failed = Emitter::default()
                         .add_instructions(&gix)?
                         .emit_to(&mut stdout_buf)?;
@@ -421,7 +421,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
         with_var("VERGEN_GIT_COMMIT_DATE", Some("this is a bad date"), || {
             let result = || -> Result<()> {
                 let mut stdout_buf = vec![];
-                let gix = GixBuilder::all_git()?;
+                let gix = Gix::all_git();
                 let _failed = Emitter::default()
                     .add_instructions(&gix)?
                     .emit_to(&mut stdout_buf)?;
@@ -445,7 +445,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
             || {
                 let result = || -> Result<()> {
                     let mut stdout_buf = vec![];
-                    let gix = GixBuilder::all_git()?;
+                    let gix = Gix::all_git();
                     let _failed = Emitter::default()
                         .add_instructions(&gix)?
                         .emit_to(&mut stdout_buf)?;
@@ -469,7 +469,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
             || {
                 let result = || -> Result<()> {
                     let mut stdout_buf = vec![];
-                    let gix = GixBuilder::all_git()?;
+                    let gix = Gix::all_git();
                     let _failed = Emitter::default()
                         .add_instructions(&gix)?
                         .emit_to(&mut stdout_buf)?;
@@ -491,7 +491,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
         with_var("VERGEN_GIT_DESCRIBE", Some("this is a bad date"), || {
             let result = || -> Result<()> {
                 let mut stdout_buf = vec![];
-                let gix = GixBuilder::all_git()?;
+                let gix = Gix::all_git();
                 let _failed = Emitter::default()
                     .add_instructions(&gix)?
                     .emit_to(&mut stdout_buf)?;
@@ -510,7 +510,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH";
         with_var("VERGEN_GIT_SHA", Some("this is a bad date"), || {
             let result = || -> Result<()> {
                 let mut stdout_buf = vec![];
-                let gix = GixBuilder::all_git()?;
+                let gix = Gix::all_git();
                 let _failed = Emitter::default()
                     .add_instructions(&gix)?
                     .emit_to(&mut stdout_buf)?;

--- a/vergen-lib/Cargo.toml
+++ b/vergen-lib/Cargo.toml
@@ -40,7 +40,7 @@ si = []
 
 [dependencies]
 anyhow = "1.0.95"
-derive_builder = "0.20.2"
+bon = "3.3.2"
 
 [build-dependencies]
 rustversion = "1.0.19"

--- a/vergen-lib/Cargo.toml
+++ b/vergen-lib/Cargo.toml
@@ -53,3 +53,6 @@ test_util = { path = "../test_util", features = ["unstable"] }
 [package.metadata.docs.rs]
 features = ["build", "cargo", "git", "rustc", "si"]
 rustdoc-args = ["--cfg", "docsrs"]
+
+[lints]
+workspace = true

--- a/vergen-lib/src/entries.rs
+++ b/vergen-lib/src/entries.rs
@@ -118,11 +118,11 @@ pub trait Add {
 /// ## Then in [`build.rs`]
 ///
 /// ```will_not_compile
-/// let build = BuildBuilder::all_build()?;
-/// let cargo = CargoBuilder::all_cargo()?;
-/// let gix = GixBuilder::all_git()?;
-/// let rustc = RustcBuilder::all_rustc()?;
-/// let si = SysinfoBuilder::all_sysinfo()?;
+/// let build = Build::all_build();
+/// let cargo = Cargo::all_cargo();
+/// let gix = Gix::all_git();
+/// let rustc = Rustc::all_rustc();
+/// let si = Sysinfo::all_sysinfo();
 /// Emitter::default()
 ///     .add_instructions(&build)?
 ///     .add_instructions(&cargo)?
@@ -175,11 +175,10 @@ pub trait AddCustom<K: Into<String> + Ord, V: Into<String>> {
 pub(crate) mod test_gen {
     use crate::{AddCustomEntries, CargoRerunIfChanged, CargoWarning};
     use anyhow::{anyhow, Result};
-    use derive_builder::Builder;
     use std::collections::BTreeMap;
 
     #[doc(hidden)]
-    #[derive(Builder, Clone, Copy, Debug, Default)]
+    #[derive(Clone, Copy, Debug, Default, bon::Builder)]
     pub struct CustomInsGen {
         fail: bool,
     }

--- a/vergen-lib/src/entries.rs
+++ b/vergen-lib/src/entries.rs
@@ -10,7 +10,7 @@ pub type CargoRerunIfChanged = Vec<String>;
 /// The vector of strings used to emit `cargo:warning=VALUE` cargo instructions
 pub type CargoWarning = Vec<String>;
 
-/// The default configuration to use when an issue has occured generating instructions
+/// The default configuration to use when an issue has occurred generating instructions
 #[derive(Debug)]
 pub struct DefaultConfig {
     /// Should we fail if an error occurs or output idempotent values on error?
@@ -62,7 +62,7 @@ pub trait Add {
         cargo_warning: &mut CargoWarning,
     ) -> Result<()>;
 
-    /// Based on the given configuration, emit either default idempotent output or generate a failue.
+    /// Based on the given configuration, emit either default idempotent output or generate a failure.
     ///
     /// * Write to the `cargo_rustc_env` map to emit 'cargo:rustc-env=NAME=VALUE' instructions.
     /// * Write to the `cargo_rerun_if_changed` vector to emit 'cargo:rerun-if-changed=VALUE' instructions.
@@ -152,7 +152,7 @@ pub trait AddCustom<K: Into<String> + Ord, V: Into<String>> {
         cargo_warning: &mut CargoWarning,
     ) -> Result<()>;
 
-    /// Based on the given configuration, emit either default idempotent output or generate a failue.
+    /// Based on the given configuration, emit either default idempotent output or generate a failure.
     ///
     /// * Write to the `cargo_rustc_env` map to emit 'cargo:rustc-env=NAME=VALUE' instructions.
     /// * Write to the `cargo_rerun_if_changed` vector to emit 'cargo:rerun-if-changed=VALUE' instructions.

--- a/vergen-lib/src/git_config.rs
+++ b/vergen-lib/src/git_config.rs
@@ -1,0 +1,18 @@
+//! Shared git configuration for different git libraries
+
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct Describe {
+    pub tags: bool,
+    pub dirty: bool,
+    pub match_pattern: Option<&'static str>,
+}
+
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct Dirty {
+    pub include_untracked: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct Sha {
+    pub short: bool,
+}

--- a/vergen-lib/src/lib.rs
+++ b/vergen-lib/src/lib.rs
@@ -220,6 +220,7 @@ use {temp_env as _, test_util as _};
 pub mod constants;
 mod emitter;
 mod entries;
+pub mod git_config;
 mod keys;
 mod utils;
 

--- a/vergen-pretty/Cargo.toml
+++ b/vergen-pretty/Cargo.toml
@@ -42,7 +42,7 @@ __vergen_empty_test = ["vergen-gix", "vergen-gix/unstable"]
 anyhow = "1.0.95"
 console = { version = "0.15.10", optional = true }
 convert_case = "0.6.0"
-derive_builder = "0.20.2"
+bon = "3.3.2"
 lazy_static = { version = "1.5.0", optional = true }
 rand = { version = "0.8.5", optional = true }
 serde = { version = "1.0.217", features = ["derive"], optional = true }

--- a/vergen-pretty/build.rs
+++ b/vergen-pretty/build.rs
@@ -6,8 +6,8 @@ use vergen_gix::Emitter;
 use {
     std::collections::BTreeMap,
     vergen_gix::{
-        AddCustomEntries, BuildBuilder, CargoBuilder, CargoRerunIfChanged, CargoWarning,
-        DefaultConfig, Emitter, GixBuilder, RustcBuilder, SysinfoBuilder,
+        AddCustomEntries, Build, Cargo, CargoRerunIfChanged, CargoWarning,
+        DefaultConfig, Emitter, Gix, Rustc, Sysinfo,
     },
 };
 
@@ -68,11 +68,11 @@ impl AddCustomEntries<&str, &str> for Custom {
 #[cfg(all(feature = "__vergen_test", not(feature = "__vergen_empty_test")))]
 fn emit() -> Result<()> {
     println!("cargo:warning=VERGEN TEST ENABLED!");
-    let build = BuildBuilder::all_build()?;
-    let cargo = CargoBuilder::all_cargo()?;
-    let gix = GixBuilder::all_git()?;
-    let rustc = RustcBuilder::all_rustc()?;
-    let si = SysinfoBuilder::all_sysinfo()?;
+    let build = Build::all_build();
+    let cargo = Cargo::all_cargo();
+    let gix = Gix::all_git();
+    let rustc = Rustc::all_rustc();
+    let si = Sysinfo::all_sysinfo();
     Emitter::default()
         .add_instructions(&build)?
         .add_instructions(&cargo)?

--- a/vergen-pretty/src/header/mod.rs
+++ b/vergen-pretty/src/header/mod.rs
@@ -8,11 +8,11 @@
 
 // Header
 
-use crate::{Prefix, PrefixBuilder, PrettyBuilder, Suffix, SuffixBuilder};
+use crate::{Prefix, Pretty, Suffix};
 
 use anyhow::Result;
 use console::Style;
-use derive_builder::Builder;
+use bon::Builder;
 #[cfg(feature = "color")]
 use rand::Rng;
 use std::{collections::BTreeMap, io::Write};
@@ -39,17 +39,17 @@ pub type Env = BTreeMap<&'static str, Option<&'static str>>;
 /// # Example
 /// ```
 /// # use anyhow::Result;
-/// # use vergen_pretty::{ConfigBuilder, header, vergen_pretty_env};
+/// # use vergen_pretty::{Config, header, vergen_pretty_env};
 #[cfg_attr(feature = "color", doc = r"use vergen_pretty::Style;")]
 /// #
 /// # pub fn main() -> Result<()> {
 /// let mut buf = vec![];
-/// let config = ConfigBuilder::default()
+/// let config = Config::builder()
 #[cfg_attr(feature = "color", doc = r"    .style(Style::new().green())")]
 ///     .prefix("HEADER_PREFIX")
 ///     .env(vergen_pretty_env!())
 ///     .suffix("HEADER_SUFFIX")
-///     .build()?;
+///     .build();
 /// assert!(header(&config, Some(&mut buf)).is_ok());
 /// assert!(!buf.is_empty());
 /// #     Ok(())
@@ -63,16 +63,13 @@ pub struct Config {
     /// Use a random [`Style`] color for the output
     random_style: bool,
     #[cfg(feature = "color")]
-    #[builder(setter(into, strip_option), default)]
     /// Use the given [`Style`] for the output (mutually exclusive with `random_style`)
     style: Option<Style>,
     /// An optional prefix string
-    #[builder(setter(into, strip_option), default)]
     prefix: Option<&'static str>,
     /// The vergen env (generated with the [`vergen_pretty_env`](crate::vergen_pretty_env) macro)
     env: Env,
     /// An optional suffix string
-    #[builder(setter(into, strip_option), default)]
     suffix: Option<&'static str>,
 }
 
@@ -81,15 +78,15 @@ pub struct Config {
 /// # Example
 /// ```
 /// # use anyhow::Result;
-/// # use vergen_pretty::{ConfigBuilder, header, vergen_pretty_env};
+/// # use vergen_pretty::{Config, header, vergen_pretty_env};
 /// #
 /// # pub fn main() -> Result<()> {
 /// let mut buf = vec![];
-/// let config = ConfigBuilder::default()
+/// let config = Config::builder()
 ///     .prefix("HEADER_PREFIX")
 ///     .env(vergen_pretty_env!())
 ///     .suffix("HEADER_SUFFIX")
-///     .build()?;
+///     .build();
 /// assert!(header(&config, Some(&mut buf)).is_ok());
 /// assert!(!buf.is_empty());
 /// #     Ok(())
@@ -117,11 +114,11 @@ where
     T: Write + ?Sized,
 {
     let app_style = get_style(config.random_style, config.style.clone());
-    PrettyBuilder::default()
+    Pretty::builder()
         .env(config.env.clone())
         .prefix(get_prefix(config.prefix, &app_style)?)
         .suffix(get_suffix(config.suffix, &app_style)?)
-        .build()?
+        .build()
         .display(writer)?;
     Ok(())
 }
@@ -132,11 +129,11 @@ where
     T: Write + ?Sized,
 {
     let app_style = get_style(false, None);
-    PrettyBuilder::default()
+    Pretty::builder()
         .env(config.env.clone())
         .prefix(get_prefix(config.prefix, &app_style)?)
         .suffix(get_suffix(config.suffix, &app_style)?)
-        .build()?
+        .build()
         .display(writer)?;
     Ok(())
 }
@@ -144,11 +141,11 @@ where
 #[cfg(all(feature = "trace", feature = "color"))]
 fn trace(config: &Config) -> Result<()> {
     let app_style = get_style(config.random_style, config.style.clone());
-    PrettyBuilder::default()
+    Pretty::builder()
         .env(config.env.clone())
         .prefix(get_prefix(config.prefix, &app_style)?)
         .suffix(get_suffix(config.suffix, &app_style)?)
-        .build()?
+        .build()
         .trace();
     Ok(())
 }
@@ -156,11 +153,11 @@ fn trace(config: &Config) -> Result<()> {
 #[cfg(all(feature = "trace", not(feature = "color")))]
 fn trace(config: &Config) -> Result<()> {
     let app_style = get_style(false, None);
-    PrettyBuilder::default()
+    Pretty::builder()
         .env(config.env.clone())
         .prefix(get_prefix(config.prefix, &app_style)?)
         .suffix(get_suffix(config.suffix, &app_style)?)
-        .build()?
+        .build()
         .trace();
     Ok(())
 }
@@ -192,46 +189,46 @@ fn get_style(_random_style: bool, _style_opt: Option<Style>) -> Style {
 #[cfg(feature = "color")]
 fn get_prefix(prefix_opt: Option<&'static str>, app_style: &Style) -> Result<Prefix> {
     Ok(if let Some(prefix) = prefix_opt {
-        PrefixBuilder::default()
+        Prefix::builder()
             .lines(prefix.lines().map(str::to_string).collect())
             .style(app_style.clone())
-            .build()?
+            .build()
     } else {
-        PrefixBuilder::default().lines(vec![]).build()?
+        Prefix::builder().lines(vec![]).build()
     })
 }
 
 #[cfg(not(feature = "color"))]
 fn get_prefix(prefix_opt: Option<&'static str>, _app_style: &Style) -> Result<Prefix> {
     Ok(if let Some(prefix) = prefix_opt {
-        PrefixBuilder::default()
+        Prefix::builder()
             .lines(prefix.lines().map(str::to_string).collect())
-            .build()?
+            .build()
     } else {
-        PrefixBuilder::default().lines(vec![]).build()?
+        Prefix::builder().lines(vec![]).build()
     })
 }
 
 #[cfg(feature = "color")]
 fn get_suffix(suffix_opt: Option<&'static str>, app_style: &Style) -> Result<Suffix> {
     Ok(if let Some(suffix) = suffix_opt {
-        SuffixBuilder::default()
+        Suffix::builder()
             .lines(suffix.lines().map(str::to_string).collect())
             .style(app_style.clone())
-            .build()?
+            .build()
     } else {
-        SuffixBuilder::default().lines(vec![]).build()?
+        Suffix::builder().lines(vec![]).build()
     })
 }
 
 #[cfg(not(feature = "color"))]
 fn get_suffix(suffix_opt: Option<&'static str>, _app_style: &Style) -> Result<Suffix> {
     Ok(if let Some(suffix) = suffix_opt {
-        SuffixBuilder::default()
+        Suffix::builder()
             .lines(suffix.lines().map(str::to_string).collect())
-            .build()?
+            .build()
     } else {
-        SuffixBuilder::default().lines(vec![]).build()?
+        Suffix::builder().lines(vec![]).build()
     })
 }
 
@@ -255,7 +252,7 @@ mod test {
 ██████╔╝██║   ██║██║  ██║██║ █╗ ██║
 ██╔═══╝ ██║   ██║██║  ██║██║███╗██║
 ██║     ╚██████╔╝██████╔╝╚███╔███╔╝
-╚═╝      ╚═════╝ ╚═════╝  ╚══╝╚══╝ 
+╚═╝      ╚═════╝ ╚═════╝  ╚══╝╚══╝
 
 4a61736f6e204f7a696173
 ";
@@ -304,15 +301,18 @@ mod test {
     #[test]
     #[cfg(feature = "__vergen_test")]
     fn header_default() -> Result<()> {
-        use super::ConfigBuilder;
+        use super::Config;
         use crate::vergen_pretty_env;
 
         let mut buf = vec![];
-        let config = ConfigBuilder::default().env(vergen_pretty_env!()).build()?;
+        let config = Config::builder().env(vergen_pretty_env!()).build();
         assert!(header(&config, Some(&mut buf)).is_ok());
         assert!(!buf.is_empty());
         let header_str = String::from_utf8_lossy(&buf);
-        assert!(BUILD_TIMESTAMP.is_match(&header_str));
+        assert!(
+            BUILD_TIMESTAMP.is_match(&header_str),
+            "header: '{header_str}'"
+        );
         assert!(BUILD_SEMVER.is_match(&header_str));
         assert!(GIT_BRANCH.is_match(&header_str));
         Ok(())
@@ -321,11 +321,11 @@ mod test {
     #[test]
     #[cfg(feature = "__vergen_test")]
     fn header_no_writer() -> Result<()> {
-        use super::ConfigBuilder;
+        use super::Config;
         use crate::vergen_pretty_env;
 
         let buf: Vec<u8> = vec![];
-        let config = ConfigBuilder::default().env(vergen_pretty_env!()).build()?;
+        let config = Config::builder().env(vergen_pretty_env!()).build();
         assert!(header(&config, None::<&mut Vec<u8>>).is_ok());
         assert!(buf.is_empty());
         Ok(())
@@ -334,15 +334,15 @@ mod test {
     #[test]
     #[cfg(feature = "__vergen_test")]
     fn header_all() -> Result<()> {
-        use super::ConfigBuilder;
+        use super::Config;
         use crate::vergen_pretty_env;
 
         let mut buf = vec![];
-        let config = ConfigBuilder::default()
+        let config = Config::builder()
             .prefix(HEADER_PREFIX)
             .env(vergen_pretty_env!())
             .suffix(HEADER_SUFFIX)
-            .build()?;
+            .build();
         assert!(header(&config, Some(&mut buf)).is_ok());
         assert!(!buf.is_empty());
         let header_str = String::from_utf8_lossy(&buf);
@@ -355,16 +355,16 @@ mod test {
     #[test]
     #[cfg(all(feature = "__vergen_test", feature = "color"))]
     fn header_all_color_random() -> Result<()> {
-        use super::ConfigBuilder;
+        use super::Config;
         use crate::vergen_pretty_env;
 
         let mut buf = vec![];
-        let config = ConfigBuilder::default()
+        let config = Config::builder()
             .random_style(true)
             .prefix(HEADER_PREFIX)
             .env(vergen_pretty_env!())
             .suffix(HEADER_SUFFIX)
-            .build()?;
+            .build();
         assert!(header(&config, Some(&mut buf)).is_ok());
         assert!(!buf.is_empty());
         let header_str = String::from_utf8_lossy(&buf);
@@ -377,16 +377,16 @@ mod test {
     #[test]
     #[cfg(all(feature = "__vergen_test", feature = "color"))]
     fn header_all_color_specific() -> Result<()> {
-        use super::ConfigBuilder;
+        use super::Config;
         use crate::vergen_pretty_env;
 
         let mut buf = vec![];
-        let config = ConfigBuilder::default()
+        let config = Config::builder()
             .style(Style::new().green())
             .prefix(HEADER_PREFIX)
             .env(vergen_pretty_env!())
             .suffix(HEADER_SUFFIX)
-            .build()?;
+            .build();
         assert!(header(&config, Some(&mut buf)).is_ok());
         assert!(!buf.is_empty());
         let header_str = String::from_utf8_lossy(&buf);
@@ -400,14 +400,14 @@ mod test {
     #[cfg(debug_assertions)]
     #[cfg(feature = "__vergen_test")]
     fn header_writes() -> Result<()> {
-        use super::ConfigBuilder;
+        use super::Config;
         use crate::vergen_pretty_env;
 
         let mut buf = vec![];
-        let config = ConfigBuilder::default()
+        let config = Config::builder()
             .prefix(HEADER_PREFIX)
             .env(vergen_pretty_env!())
-            .build()?;
+            .build();
         assert!(header(&config, Some(&mut buf)).is_ok());
         assert!(!buf.is_empty());
         let header_str = String::from_utf8_lossy(&buf);
@@ -421,14 +421,14 @@ mod test {
     #[cfg(not(debug_assertions))]
     #[cfg(feature = "__vergen_test")]
     fn header_writes() -> Result<()> {
-        use super::ConfigBuilder;
+        use super::Config;
         use crate::vergen_pretty_env;
 
         let mut buf = vec![];
-        let config = ConfigBuilder::default()
+        let config = Config::builder()
             .prefix(HEADER_PREFIX)
             .env(vergen_pretty_env!())
-            .build()?;
+            .build();
         assert!(header(&config, Some(&mut buf)).is_ok());
         assert!(!buf.is_empty());
         let header_str = String::from_utf8_lossy(&buf);

--- a/vergen-pretty/src/header/mod.rs
+++ b/vergen-pretty/src/header/mod.rs
@@ -11,8 +11,8 @@
 use crate::{Prefix, Pretty, Suffix};
 
 use anyhow::Result;
-use console::Style;
 use bon::Builder;
+use console::Style;
 #[cfg(feature = "color")]
 use rand::Rng;
 use std::{collections::BTreeMap, io::Write};
@@ -309,10 +309,7 @@ mod test {
         assert!(header(&config, Some(&mut buf)).is_ok());
         assert!(!buf.is_empty());
         let header_str = String::from_utf8_lossy(&buf);
-        assert!(
-            BUILD_TIMESTAMP.is_match(&header_str),
-            "header: '{header_str}'"
-        );
+        assert!(BUILD_TIMESTAMP.is_match(&header_str));
         assert!(BUILD_SEMVER.is_match(&header_str));
         assert!(GIT_BRANCH.is_match(&header_str));
         Ok(())

--- a/vergen-pretty/src/lib.rs
+++ b/vergen-pretty/src/lib.rs
@@ -17,7 +17,7 @@
 //! ```
 //! # use anyhow::Result;
 //! # use std::{collections::BTreeMap, io::Write};
-//! # use vergen_pretty::{vergen_pretty_env, PrettyBuilder};
+//! # use vergen_pretty::{vergen_pretty_env, Pretty};
 //! # fn has_value(
 //! #     tuple: (&&'static str, &Option<&'static str>),
 //! # ) -> Option<(&'static str, &'static str)> {
@@ -35,9 +35,9 @@
 //! let mut stdout = vec![];
 //! # let map = vergen_pretty_env!();
 //! # let empty = is_empty(&map);
-//! PrettyBuilder::default()
+//! Pretty::builder()
 //!     .env(vergen_pretty_env!())
-//!     .build()?
+//!     .build()
 //!     .display(&mut stdout)?;
 //! # if empty {
 //! #    assert!(stdout.is_empty());
@@ -58,7 +58,7 @@ with the associated [`Config`] as a convenience wrapper around [`Pretty`].
 # Example
 ```
 # use anyhow::Result;
-# use vergen_pretty::{ConfigBuilder, header, vergen_pretty_env};"
+# use vergen_pretty::{Config, header, vergen_pretty_env};"
 )]
 #![cfg_attr(feature = "color", doc = r"# use vergen_pretty::Style;")]
 #![cfg_attr(
@@ -67,7 +67,7 @@ with the associated [`Config`] as a convenience wrapper around [`Pretty`].
 #
 # pub fn main() -> Result<()> {
 let mut buf = vec![];
-let config = ConfigBuilder::default()"
+let config = Config::builder()"
 )]
 #![cfg_attr(
     all(feature = "color", feature = "header"),
@@ -79,7 +79,7 @@ let config = ConfigBuilder::default()"
     .prefix("HEADER_PREFIX")
     .env(vergen_pretty_env!())
     .suffix("HEADER_SUFFIX")
-    .build()?;
+    .build();
 assert!(header(&config, Some(&mut buf)).is_ok());
 assert!(!buf.is_empty());
 #     Ok(())
@@ -89,7 +89,7 @@ assert!(!buf.is_empty());
 )]
 //!
 //! ## Features
-//! `vergen-pretty` has two feature toggles allowing you to customize your output. No features are enabled by default.  
+//! `vergen-pretty` has two feature toggles allowing you to customize your output. No features are enabled by default.
 //! You **must** specifically enable the features you wish to use.
 //!
 //! | Feature | Enables |
@@ -326,7 +326,6 @@ pub use pretty::suffix::Suffix;
 pub use pretty::suffix::SuffixBuilder;
 pub use pretty::Pretty;
 pub use pretty::PrettyBuilder;
-pub use pretty::PrettyBuilderError;
 #[cfg(feature = "trace")]
 #[doc(inline)]
 pub use tracing::Level;
@@ -352,13 +351,13 @@ use tracing_subscriber as _;
 /// ```
 /// # use anyhow::Result;
 /// # use std::{collections::BTreeMap, io::Write};
-/// # use vergen_pretty::{vergen_pretty_env, PrettyBuilder};
+/// # use vergen_pretty::{vergen_pretty_env, Pretty};
 /// #
 /// # fn main() -> Result<()> {
 /// let mut stdout = vec![];
-/// PrettyBuilder::default()
+/// Pretty::builder()
 ///     .env(vergen_pretty_env!())
-///     .build()?
+///     .build()
 ///     .display(&mut stdout)?;
 /// #     Ok(())
 /// # }

--- a/vergen-pretty/src/pretty/feature/color.rs
+++ b/vergen-pretty/src/pretty/feature/color.rs
@@ -75,7 +75,7 @@ impl Suffix {
 mod test {
     use crate::{
         utils::test_utils::{is_empty, TEST_PREFIX_SUFFIX},
-        vergen_pretty_env, PrefixBuilder, PrettyBuilder, SuffixBuilder,
+        vergen_pretty_env, Prefix, Pretty, Suffix,
     };
     use anyhow::Result;
     use console::Style;
@@ -86,10 +86,7 @@ mod test {
         let red_bold = Style::new().bold().red();
         let map = vergen_pretty_env!();
         let empty = is_empty(&map);
-        let fmt = PrettyBuilder::default()
-            .env(map)
-            .key_style(red_bold)
-            .build()?;
+        let fmt = Pretty::builder().env(map).key_style(red_bold).build();
         fmt.display(&mut stdout)?;
         if empty {
             assert!(stdout.is_empty());
@@ -105,10 +102,7 @@ mod test {
         let map = vergen_pretty_env!();
         let empty = is_empty(&map);
         let red_bold = Style::new().bold().red();
-        let fmt = PrettyBuilder::default()
-            .env(map)
-            .value_style(red_bold)
-            .build()?;
+        let fmt = Pretty::builder().env(map).value_style(red_bold).build();
         fmt.display(&mut stdout)?;
         if empty {
             assert!(stdout.is_empty());
@@ -123,11 +117,11 @@ mod test {
         let mut stdout = vec![];
         let map = vergen_pretty_env!();
         let red_bold = Style::new().bold().red();
-        let prefix = PrefixBuilder::default()
+        let prefix = Prefix::builder()
             .lines(TEST_PREFIX_SUFFIX.lines().map(str::to_string).collect())
             .style(red_bold)
-            .build()?;
-        let fmt = PrettyBuilder::default().env(map).prefix(prefix).build()?;
+            .build();
+        let fmt = Pretty::builder().env(map).prefix(prefix).build();
         fmt.display(&mut stdout)?;
         assert!(!stdout.is_empty());
         Ok(())
@@ -138,11 +132,11 @@ mod test {
         let mut stdout = vec![];
         let map = vergen_pretty_env!();
         let red_bold = Style::new().bold().red();
-        let suffix = SuffixBuilder::default()
+        let suffix = Suffix::builder()
             .lines(TEST_PREFIX_SUFFIX.lines().map(str::to_string).collect())
             .style(red_bold)
-            .build()?;
-        let fmt = PrettyBuilder::default().env(map).suffix(suffix).build()?;
+            .build();
+        let fmt = Pretty::builder().env(map).suffix(suffix).build();
         fmt.display(&mut stdout)?;
         assert!(!stdout.is_empty());
         Ok(())

--- a/vergen-pretty/src/pretty/feature/serde.rs
+++ b/vergen-pretty/src/pretty/feature/serde.rs
@@ -64,10 +64,7 @@ impl Serialize for VarsTuple {
 
 #[cfg(test)]
 mod test {
-    use crate::{
-        utils::test_utils::TEST_PREFIX_SUFFIX, vergen_pretty_env, PrefixBuilder, PrettyBuilder,
-        SuffixBuilder,
-    };
+    use crate::{utils::test_utils::TEST_PREFIX_SUFFIX, vergen_pretty_env, Prefix, Pretty, Suffix};
     use anyhow::Result;
 
     const VARS: &str = r#"vars":{"#;
@@ -76,7 +73,7 @@ mod test {
 
     #[test]
     fn pretty_serialize_works() -> Result<()> {
-        let pretty = PrettyBuilder::default().env(vergen_pretty_env!()).build()?;
+        let pretty = Pretty::builder().env(vergen_pretty_env!()).build();
         let val = serde_json::to_string(&pretty)?;
         assert!(val.contains(VARS));
         Ok(())
@@ -84,13 +81,13 @@ mod test {
 
     #[test]
     fn pretty_with_prefix_serialize_works() -> Result<()> {
-        let prefix = PrefixBuilder::default()
+        let prefix = Prefix::builder()
             .lines(TEST_PREFIX_SUFFIX.lines().map(str::to_string).collect())
-            .build()?;
-        let pretty = PrettyBuilder::default()
+            .build();
+        let pretty = Pretty::builder()
             .env(vergen_pretty_env!())
             .prefix(prefix)
-            .build()?;
+            .build();
         let val = serde_json::to_string(&pretty)?;
         assert!(val.contains(VARS));
         assert!(val.contains(PREFIX));
@@ -99,13 +96,13 @@ mod test {
 
     #[test]
     fn pretty_with_suffix_serialize_works() -> Result<()> {
-        let suffix = SuffixBuilder::default()
+        let suffix = Suffix::builder()
             .lines(TEST_PREFIX_SUFFIX.lines().map(str::to_string).collect())
-            .build()?;
-        let pretty = PrettyBuilder::default()
+            .build();
+        let pretty = Pretty::builder()
             .env(vergen_pretty_env!())
             .suffix(suffix)
-            .build()?;
+            .build();
         let val = serde_json::to_string(&pretty)?;
         assert!(val.contains(VARS));
         assert!(val.contains(SUFFIX));
@@ -114,10 +111,10 @@ mod test {
 
     #[test]
     fn pretty_with_flatten_serialize_works() -> Result<()> {
-        let pretty = PrettyBuilder::default()
+        let pretty = Pretty::builder()
             .env(vergen_pretty_env!())
             .flatten(true)
-            .build()?;
+            .build();
         let val = serde_json::to_string(&pretty)?;
         assert!(!val.contains(VARS));
         assert!(!val.contains(PREFIX));

--- a/vergen-pretty/src/pretty/feature/trace.rs
+++ b/vergen-pretty/src/pretty/feature/trace.rs
@@ -151,8 +151,8 @@ impl Suffix {
 #[cfg(test)]
 mod test {
     use crate::{
-        utils::test_utils::TEST_PREFIX_SUFFIX, vergen_pretty_env, PrefixBuilder, PrettyBuilder,
-        SuffixBuilder,
+        utils::test_utils::TEST_PREFIX_SUFFIX, vergen_pretty_env, Prefix, Pretty,
+        Suffix,
     };
     use anyhow::Result;
     #[cfg(feature = "color")]
@@ -180,9 +180,9 @@ mod test {
     #[test]
     fn default_trace_works() -> Result<()> {
         initialize_tracing();
-        PrettyBuilder::default()
+        Pretty::builder()
             .env(vergen_pretty_env!())
-            .build()?
+            .build()
             .trace();
         Ok(())
     }
@@ -191,20 +191,20 @@ mod test {
     fn trace_debug_works() -> Result<()> {
         initialize_tracing();
         let level = Level::DEBUG;
-        let prefix = PrefixBuilder::default()
+        let prefix = Prefix::builder()
             .lines(TEST_PREFIX_SUFFIX.lines().map(str::to_string).collect())
             .level(level)
-            .build()?;
-        let suffix = SuffixBuilder::default()
+            .build();
+        let suffix = Suffix::builder()
             .lines(TEST_PREFIX_SUFFIX.lines().map(str::to_string).collect())
             .level(level)
-            .build()?;
-        PrettyBuilder::default()
+            .build();
+        Pretty::builder()
             .env(vergen_pretty_env!())
             .level(level)
             .prefix(prefix)
             .suffix(suffix)
-            .build()?
+            .build()
             .trace();
         Ok(())
     }
@@ -213,20 +213,20 @@ mod test {
     fn default_trace_trace_works() -> Result<()> {
         initialize_tracing();
         let level = Level::TRACE;
-        let prefix = PrefixBuilder::default()
+        let prefix = Prefix::builder()
             .lines(TEST_PREFIX_SUFFIX.lines().map(str::to_string).collect())
             .level(level)
-            .build()?;
-        let suffix = SuffixBuilder::default()
+            .build();
+        let suffix = Suffix::builder()
             .lines(TEST_PREFIX_SUFFIX.lines().map(str::to_string).collect())
             .level(level)
-            .build()?;
-        PrettyBuilder::default()
+            .build();
+        Pretty::builder()
             .env(vergen_pretty_env!())
             .level(level)
             .prefix(prefix)
             .suffix(suffix)
-            .build()?
+            .build()
             .trace();
         Ok(())
     }
@@ -235,20 +235,20 @@ mod test {
     fn default_trace_error_works() -> Result<()> {
         initialize_tracing();
         let level = Level::ERROR;
-        let prefix = PrefixBuilder::default()
+        let prefix = Prefix::builder()
             .lines(TEST_PREFIX_SUFFIX.lines().map(str::to_string).collect())
             .level(level)
-            .build()?;
-        let suffix = SuffixBuilder::default()
+            .build();
+        let suffix = Suffix::builder()
             .lines(TEST_PREFIX_SUFFIX.lines().map(str::to_string).collect())
             .level(level)
-            .build()?;
-        PrettyBuilder::default()
+            .build();
+        Pretty::builder()
             .env(vergen_pretty_env!())
             .level(level)
             .prefix(prefix)
             .suffix(suffix)
-            .build()?
+            .build()
             .trace();
         Ok(())
     }
@@ -257,20 +257,20 @@ mod test {
     fn default_trace_warn_works() -> Result<()> {
         initialize_tracing();
         let level = Level::WARN;
-        let prefix = PrefixBuilder::default()
+        let prefix = Prefix::builder()
             .lines(TEST_PREFIX_SUFFIX.lines().map(str::to_string).collect())
             .level(level)
-            .build()?;
-        let suffix = SuffixBuilder::default()
+            .build();
+        let suffix = Suffix::builder()
             .lines(TEST_PREFIX_SUFFIX.lines().map(str::to_string).collect())
             .level(level)
-            .build()?;
-        PrettyBuilder::default()
+            .build();
+        Pretty::builder()
             .env(vergen_pretty_env!())
             .level(level)
             .prefix(prefix)
             .suffix(suffix)
-            .build()?
+            .build()
             .trace();
         Ok(())
     }
@@ -280,10 +280,10 @@ mod test {
     fn trace_key_style_works() -> Result<()> {
         initialize_tracing();
         let red_bold = Style::new().bold().red();
-        PrettyBuilder::default()
+        Pretty::builder()
             .env(vergen_pretty_env!())
             .key_style(red_bold)
-            .build()?
+            .build()
             .trace();
         Ok(())
     }
@@ -293,10 +293,10 @@ mod test {
     fn trace_value_style_works() -> Result<()> {
         initialize_tracing();
         let red_bold = Style::new().bold().red();
-        PrettyBuilder::default()
+        Pretty::builder()
             .env(vergen_pretty_env!())
             .value_style(red_bold)
-            .build()?
+            .build()
             .trace();
         Ok(())
     }
@@ -304,13 +304,13 @@ mod test {
     #[test]
     fn trace_prefix_works() -> Result<()> {
         initialize_tracing();
-        let prefix = PrefixBuilder::default()
+        let prefix = Prefix::builder()
             .lines(TEST_PREFIX_SUFFIX.lines().map(str::to_string).collect())
-            .build()?;
-        PrettyBuilder::default()
+            .build();
+        Pretty::builder()
             .env(vergen_pretty_env!())
             .prefix(prefix)
-            .build()?
+            .build()
             .trace();
         Ok(())
     }
@@ -320,14 +320,14 @@ mod test {
     fn trace_prefix_with_style_works() -> Result<()> {
         initialize_tracing();
         let red_bold = Style::new().bold().red();
-        let prefix = PrefixBuilder::default()
+        let prefix = Prefix::builder()
             .lines(TEST_PREFIX_SUFFIX.lines().map(str::to_string).collect())
             .style(red_bold)
-            .build()?;
-        PrettyBuilder::default()
+            .build();
+        Pretty::builder()
             .env(vergen_pretty_env!())
             .prefix(prefix)
-            .build()?
+            .build()
             .trace();
         Ok(())
     }
@@ -335,13 +335,13 @@ mod test {
     #[test]
     fn trace_suffix_works() -> Result<()> {
         initialize_tracing();
-        let suffix = SuffixBuilder::default()
+        let suffix = Suffix::builder()
             .lines(TEST_PREFIX_SUFFIX.lines().map(str::to_string).collect())
-            .build()?;
-        PrettyBuilder::default()
+            .build();
+        Pretty::builder()
             .env(vergen_pretty_env!())
             .suffix(suffix)
-            .build()?
+            .build()
             .trace();
         Ok(())
     }
@@ -351,14 +351,14 @@ mod test {
     fn trace_suffix_with_style_works() -> Result<()> {
         initialize_tracing();
         let red_bold = Style::new().bold().red();
-        let suffix = SuffixBuilder::default()
+        let suffix = Suffix::builder()
             .lines(TEST_PREFIX_SUFFIX.lines().map(str::to_string).collect())
             .style(red_bold)
-            .build()?;
-        PrettyBuilder::default()
+            .build();
+        Pretty::builder()
             .env(vergen_pretty_env!())
             .suffix(suffix)
-            .build()?
+            .build()
             .trace();
         Ok(())
     }
@@ -366,10 +366,10 @@ mod test {
     #[test]
     fn trace_with_filter_works() -> Result<()> {
         initialize_tracing();
-        PrettyBuilder::default()
+        Pretty::builder()
             .env(vergen_pretty_env!())
             .filter(vec!["VERGEN_GIT_BRANCH", "VERGEN_SYSINFO_USER"])
-            .build()?
+            .build()
             .trace();
         Ok(())
     }

--- a/vergen-pretty/src/pretty/prefix.rs
+++ b/vergen-pretty/src/pretty/prefix.rs
@@ -9,7 +9,7 @@
 use anyhow::Result;
 #[cfg(feature = "color")]
 use console::Style;
-use derive_builder::Builder;
+use bon::Builder;
 #[cfg(feature = "serde")]
 use serde::Serialize;
 use std::io::Write;
@@ -24,12 +24,11 @@ pub struct Prefix {
     pub(crate) lines: Vec<String>,
     /// The [`Style`] to apply to the output lines
     #[cfg(feature = "color")]
-    #[builder(setter(strip_option, into), default)]
     #[cfg_attr(feature = "serde", serde(skip))]
     pub(crate) style: Option<Style>,
     /// The tracing [`Level`] to output the prefix at
     #[cfg(feature = "trace")]
-    #[builder(default = "Level::INFO")]
+    #[builder(default = Level::INFO)]
     #[cfg_attr(feature = "serde", serde(skip))]
     pub(crate) level: Level,
 }
@@ -64,7 +63,7 @@ impl Prefix {
 #[cfg(test)]
 mod test {
     use crate::{
-        utils::test_utils::TEST_PREFIX_SUFFIX, vergen_pretty_env, PrefixBuilder, PrettyBuilder,
+        utils::test_utils::TEST_PREFIX_SUFFIX, vergen_pretty_env, Prefix, Pretty,
     };
     use anyhow::Result;
     use std::io::Write;
@@ -72,9 +71,9 @@ mod test {
     #[test]
     #[allow(clippy::clone_on_copy, clippy::redundant_clone)]
     fn prefix_clone_works() -> Result<()> {
-        let prefix = PrefixBuilder::default()
+        let prefix = Prefix::builder()
             .lines(TEST_PREFIX_SUFFIX.lines().map(str::to_string).collect())
-            .build()?;
+            .build();
         let another = prefix.clone();
         assert_eq!(prefix, another);
         Ok(())
@@ -82,9 +81,9 @@ mod test {
 
     #[test]
     fn prefix_debug_works() -> Result<()> {
-        let prefix = PrefixBuilder::default()
+        let prefix = Prefix::builder()
             .lines(TEST_PREFIX_SUFFIX.lines().map(str::to_string).collect())
-            .build()?;
+            .build();
         let mut buf = vec![];
         write!(buf, "{prefix:?}")?;
         assert!(!buf.is_empty());
@@ -95,10 +94,10 @@ mod test {
     fn display_prefix_works() -> Result<()> {
         let mut stdout = vec![];
         let map = vergen_pretty_env!();
-        let prefix = PrefixBuilder::default()
+        let prefix = Prefix::builder()
             .lines(TEST_PREFIX_SUFFIX.lines().map(str::to_string).collect())
-            .build()?;
-        let fmt = PrettyBuilder::default().env(map).prefix(prefix).build()?;
+            .build();
+        let fmt = Pretty::builder().env(map).prefix(prefix).build();
         fmt.display(&mut stdout)?;
         assert!(!stdout.is_empty());
         Ok(())

--- a/vergen-pretty/src/pretty/suffix.rs
+++ b/vergen-pretty/src/pretty/suffix.rs
@@ -9,7 +9,7 @@
 use anyhow::Result;
 #[cfg(feature = "color")]
 use console::Style;
-use derive_builder::Builder;
+use bon::Builder;
 #[cfg(feature = "serde")]
 use serde::Serialize;
 use std::io::Write;
@@ -24,12 +24,11 @@ pub struct Suffix {
     pub(crate) lines: Vec<String>,
     /// The [`Style`] to apply to the output lines
     #[cfg(feature = "color")]
-    #[builder(setter(strip_option), default)]
     #[cfg_attr(feature = "serde", serde(skip))]
     pub(crate) style: Option<Style>,
     /// The tracing [`Level`] to output the prefix at
     #[cfg(feature = "trace")]
-    #[builder(default = "Level::INFO")]
+    #[builder(default = Level::INFO)]
     #[cfg_attr(feature = "serde", serde(skip))]
     pub(crate) level: Level,
 }
@@ -62,7 +61,7 @@ impl Suffix {
 #[cfg(test)]
 mod test {
     use crate::{
-        utils::test_utils::TEST_PREFIX_SUFFIX, vergen_pretty_env, PrettyBuilder, SuffixBuilder,
+        utils::test_utils::TEST_PREFIX_SUFFIX, vergen_pretty_env, Pretty, Suffix,
     };
     use anyhow::Result;
     use std::io::Write;
@@ -70,9 +69,9 @@ mod test {
     #[test]
     #[allow(clippy::clone_on_copy, clippy::redundant_clone)]
     fn suffix_clone_works() -> Result<()> {
-        let suffix = SuffixBuilder::default()
+        let suffix = Suffix::builder()
             .lines(TEST_PREFIX_SUFFIX.lines().map(str::to_string).collect())
-            .build()?;
+            .build();
         let another = suffix.clone();
         assert_eq!(suffix, another);
         Ok(())
@@ -80,9 +79,9 @@ mod test {
 
     #[test]
     fn suffix_debug_works() -> Result<()> {
-        let suffix = SuffixBuilder::default()
+        let suffix = Suffix::builder()
             .lines(TEST_PREFIX_SUFFIX.lines().map(str::to_string).collect())
-            .build()?;
+            .build();
         let mut buf = vec![];
         write!(buf, "{suffix:?}")?;
         assert!(!buf.is_empty());
@@ -93,10 +92,10 @@ mod test {
     fn display_suffix_works() -> Result<()> {
         let mut stdout = vec![];
         let map = vergen_pretty_env!();
-        let suffix = SuffixBuilder::default()
+        let suffix = Suffix::builder()
             .lines(TEST_PREFIX_SUFFIX.lines().map(str::to_string).collect())
-            .build()?;
-        let fmt = PrettyBuilder::default().env(map).suffix(suffix).build()?;
+            .build();
+        let fmt = Pretty::builder().env(map).suffix(suffix).build();
         fmt.display(&mut stdout)?;
         assert!(!stdout.is_empty());
         Ok(())

--- a/vergen/Cargo.toml
+++ b/vergen/Cargo.toml
@@ -34,8 +34,8 @@ emit_and_set = ["vergen-lib/emit_and_set"]
 
 [dependencies]
 anyhow = "1.0.95"
+bon = "3.3.2"
 cargo_metadata = { version = "0.19.1", optional = true }
-derive_builder = "0.20.2"
 regex = { version = "1.11.1", optional = true }
 rustc_version = { version = "0.4.1", optional = true }
 sysinfo = { version = "0.33.1", optional = true }
@@ -59,3 +59,6 @@ temp-env = "0.3.6"
 [package.metadata.docs.rs]
 features = ["build", "cargo", "emit_and_set", "rustc", "si"]
 rustdoc-args = ["--cfg", "docsrs"]
+
+[lints]
+workspace = true

--- a/vergen/src/feature/build.rs
+++ b/vergen/src/feature/build.rs
@@ -34,7 +34,7 @@ use vergen_lib::{
 /// ```
 /// # use anyhow::Result;
 /// # use vergen::Emitter;
-/// # use vergen::BuildBuilder;
+/// # use vergen::Build;
 /// #
 /// # fn main() -> Result<()> {
 /// let build = Build::all_build();
@@ -48,7 +48,7 @@ use vergen_lib::{
 /// ```
 /// # use anyhow::Result;
 /// # use vergen::Emitter;
-/// # use vergen::BuildBuilder;
+/// # use vergen::Build;
 /// #
 /// # fn main() -> Result<()> {
 /// let build = Build::builder().build_timestamp(true).build();
@@ -63,7 +63,7 @@ use vergen_lib::{
 /// # use anyhow::Result;
 /// # use std::env;
 /// # use vergen::Emitter;
-/// # use vergen::BuildBuilder;
+/// # use vergen::Build;
 /// #
 /// # fn main() -> Result<()> {
 /// temp_env::with_var("VERGEN_BUILD_DATE", Some("01/01/2023"), || {
@@ -87,7 +87,7 @@ use vergen_lib::{
 /// # use anyhow::Result;
 /// # use std::env;
 /// # use vergen::Emitter;
-/// # use vergen::BuildBuilder;
+/// # use vergen::Build;
 /// #
 /// # fn main() -> Result<()> {
 /// temp_env::with_var("SOURCE_DATE_EPOCH", Some("1671809360"), || {
@@ -119,7 +119,7 @@ use vergen_lib::{
 /// ```
 /// # use anyhow::Result;
 /// # use vergen::Emitter;
-/// # use vergen::BuildBuilder;
+/// # use vergen::Build;
 /// #
 /// # fn main() -> Result<()> {
 /// let build = Build::builder().build();

--- a/vergen/src/feature/cargo.rs
+++ b/vergen/src/feature/cargo.rs
@@ -38,7 +38,7 @@ use vergen_lib::{
 /// # use anyhow::Result;
 /// # use std::env;
 /// # use vergen::Emitter;
-/// # use vergen::CargoBuilder;
+/// # use vergen::Cargo;
 /// #
 /// fn main() -> Result<()> {
 ///     temp_env::with_vars([
@@ -61,7 +61,7 @@ use vergen_lib::{
 /// ```
 /// # use anyhow::Result;
 /// # use vergen::Emitter;
-/// # use vergen::CargoBuilder;
+/// # use vergen::Cargo;
 /// #
 /// # fn main() -> Result<()> {
 ///     temp_env::with_vars([
@@ -84,7 +84,7 @@ use vergen_lib::{
 /// # use anyhow::Result;
 /// # use std::env;
 /// # use vergen::Emitter;
-/// # use vergen::CargoBuilder;
+/// # use vergen::Cargo;
 /// #
 /// fn main() -> Result<()> {
 ///     temp_env::with_vars([
@@ -535,10 +535,7 @@ mod test {
     #[serial]
     fn dependencies_bad_name_filter() {
         let result = with_cargo_vars(|| {
-            let cargo = Cargo::builder()
-                .dependencies(true)
-                .name_filter("(")
-                .build();
+            let cargo = Cargo::builder().dependencies(true).name_filter("(").build();
             let config = Emitter::default().add_instructions(&cargo)?.test_emit();
             assert_eq!(1, config.cargo_rustc_env_map().len());
             assert_eq!(0, count_idempotent(config.cargo_rustc_env_map()));

--- a/vergen/src/feature/rustc.rs
+++ b/vergen/src/feature/rustc.rs
@@ -39,7 +39,7 @@ use vergen_lib::{
 /// ```
 /// # use anyhow::Result;
 /// # use vergen::Emitter;
-/// # use vergen::RustcBuilder;
+/// # use vergen::Rustc;
 /// #
 /// # fn main() -> Result<()> {
 /// let rustc = Rustc::all_rustc();
@@ -53,7 +53,7 @@ use vergen_lib::{
 /// ```
 /// # use anyhow::Result;
 /// # use vergen::Emitter;
-/// # use vergen::RustcBuilder;
+/// # use vergen::Rustc;
 /// #
 /// # fn main() -> Result<()> {
 /// let rustc = Rustc::builder().channel(true).semver(true).build();
@@ -68,7 +68,7 @@ use vergen_lib::{
 /// # use anyhow::Result;
 /// # use std::env;
 /// # use vergen::Emitter;
-/// # use vergen::RustcBuilder;
+/// # use vergen::Rustc;
 /// #
 /// # fn main() -> Result<()> {
 /// temp_env::with_var("VERGEN_RUSTC_CHANNEL", Some("this is the channel I want output"), || {

--- a/vergen/src/feature/si.rs
+++ b/vergen/src/feature/si.rs
@@ -38,7 +38,7 @@ use vergen_lib::{
 /// ```
 /// # use anyhow::Result;
 /// # use vergen::Emitter;
-/// # use vergen::SysinfoBuilder;
+/// # use vergen::Sysinfo;
 /// #
 /// # fn main() -> Result<()> {
 /// let si = Sysinfo::all_sysinfo();
@@ -52,7 +52,7 @@ use vergen_lib::{
 /// ```
 /// # use anyhow::Result;
 /// # use vergen::Emitter;
-/// # use vergen::SysinfoBuilder;
+/// # use vergen::Sysinfo;
 /// #
 /// # fn main() -> Result<()> {
 /// let si = Sysinfo::builder().os_version(true).cpu_core_count(true).build();
@@ -69,7 +69,7 @@ use vergen_lib::{
 /// # use anyhow::Result;
 /// # use std::env;
 /// # use vergen::Emitter;
-/// # use vergen::SysinfoBuilder;
+/// # use vergen::Sysinfo;
 /// #
 /// # fn main() -> Result<()> {
 /// temp_env::with_var("VERGEN_SYSINFO_NAME", Some("this is the name I want output"), || {
@@ -90,7 +90,7 @@ use vergen_lib::{
 /// ```
 /// # use anyhow::Result;
 /// # use vergen::Emitter;
-/// # use vergen::SysinfoBuilder;
+/// # use vergen::Sysinfo;
 /// #
 /// # fn main() -> Result<()> {
 /// let si = Sysinfo::all_sysinfo();
@@ -106,7 +106,7 @@ use vergen_lib::{
 /// # use anyhow::Result;
 /// # use sysinfo::{CpuRefreshKind, RefreshKind};
 /// # use vergen::Emitter;
-/// # use vergen::SysinfoBuilder;
+/// # use vergen::Sysinfo;
 /// #
 /// # pub fn main() -> Result<()> {
 /// let refresh_kind = RefreshKind::nothing();

--- a/vergen/src/feature/si.rs
+++ b/vergen/src/feature/si.rs
@@ -7,7 +7,6 @@
 // modified, or distributed except according to those terms.
 
 use anyhow::{anyhow, Result};
-use derive_builder::Builder as DeriveBuilder;
 use std::env;
 use sysinfo::{get_current_pid, Cpu, Pid, Process, RefreshKind, System, User, Users};
 use vergen_lib::{
@@ -42,7 +41,7 @@ use vergen_lib::{
 /// # use vergen::SysinfoBuilder;
 /// #
 /// # fn main() -> Result<()> {
-/// let si = SysinfoBuilder::all_sysinfo()?;
+/// let si = Sysinfo::all_sysinfo();
 /// Emitter::default().add_instructions(&si)?.emit()?;
 /// #   Ok(())
 /// # }
@@ -56,7 +55,7 @@ use vergen_lib::{
 /// # use vergen::SysinfoBuilder;
 /// #
 /// # fn main() -> Result<()> {
-/// let si = SysinfoBuilder::default().os_version(true).cpu_core_count(true).build()?;
+/// let si = Sysinfo::builder().os_version(true).cpu_core_count(true).build();
 /// Emitter::default()
 ///     .add_instructions(&si)?
 ///     .emit()?;
@@ -75,7 +74,7 @@ use vergen_lib::{
 /// # fn main() -> Result<()> {
 /// temp_env::with_var("VERGEN_SYSINFO_NAME", Some("this is the name I want output"), || {
 ///     let result = || -> Result<()> {
-///         let si = SysinfoBuilder::all_sysinfo()?;
+///         let si = Sysinfo::all_sysinfo();
 ///         Emitter::default().add_instructions(&si)?.emit()?;
 ///         Ok(())
 ///     }();
@@ -94,7 +93,7 @@ use vergen_lib::{
 /// # use vergen::SysinfoBuilder;
 /// #
 /// # fn main() -> Result<()> {
-/// let si = SysinfoBuilder::all_sysinfo()?;
+/// let si = Sysinfo::all_sysinfo();
 /// Emitter::default().idempotent().add_instructions(&si)?.emit()?;
 /// #   Ok(())
 /// # }
@@ -114,10 +113,10 @@ use vergen_lib::{
 /// let cpu_refresh_kind = CpuRefreshKind::everything()
 ///     .without_cpu_usage()
 ///     .without_frequency();
-/// let si = SysinfoBuilder::default()
+/// let si = Sysinfo::builder()
 ///     .cpu_brand(true)
 ///     .refresh_kind(refresh_kind.with_cpu(cpu_refresh_kind))
-///     .build()?;
+///     .build();
 /// let config = Emitter::default()
 ///     .add_instructions(&si)?
 ///     .emit()?;
@@ -151,66 +150,66 @@ use vergen_lib::{
 /// cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
 /// ```
 ///
-#[derive(Clone, Copy, Debug, DeriveBuilder, PartialEq)]
+#[derive(Clone, Copy, Debug, bon::Builder, PartialEq)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct Sysinfo {
     /// Set the [`RefreshKind`](sysinfo::RefreshKind) to use during sysinfo initialization.
     ///
     /// This allows the user to control at a more fine level what `sysinfo`
     /// will refresh on initialization.
-    #[builder(default = "None", setter(into))]
     refresh_kind: Option<RefreshKind>,
     /// Enable the sysinfo name
-    #[builder(default = "false")]
+    #[builder(default)]
     name: bool,
     /// Enable the sysinfo OS version
-    #[builder(default = "false")]
+    #[builder(default)]
     os_version: bool,
     /// Enable sysinfo user
-    #[builder(default = "false")]
+    #[builder(default)]
     user: bool,
     /// Enable sysinfo memory
-    #[builder(default = "false")]
+    #[builder(default)]
     memory: bool,
     /// Enable sysinfo cpu vendor
-    #[builder(default = "false")]
+    #[builder(default)]
     cpu_vendor: bool,
     /// Enable sysinfo cpu core count
-    #[builder(default = "false")]
+    #[builder(default)]
     cpu_core_count: bool,
     /// Enable sysinfo cpu name
-    #[builder(default = "false")]
+    #[builder(default)]
     cpu_name: bool,
     /// Enable sysinfo cpu brand
-    #[builder(default = "false")]
+    #[builder(default)]
     cpu_brand: bool,
     /// Enable sysinfo cpu frequency
-    #[builder(default = "false")]
+    #[builder(default)]
     cpu_frequency: bool,
     #[cfg(test)]
-    #[builder(setter(skip))]
+    #[builder(skip)]
     fail_pid: bool,
 }
 
-impl SysinfoBuilder {
+impl Sysinfo {
     /// Enable all of the `VERGEN_SYSINFO_*` options
-    ///
-    /// # Errors
-    /// The underlying build function can error
-    ///
-    pub fn all_sysinfo() -> Result<Sysinfo> {
-        Self::default()
-            .name(true)
-            .os_version(true)
-            .user(true)
-            .memory(true)
-            .cpu_vendor(true)
-            .cpu_core_count(true)
-            .cpu_name(true)
-            .cpu_brand(true)
-            .cpu_frequency(true)
-            .build()
-            .map_err(Into::into)
+    pub fn all_sysinfo() -> Self {
+        // Not using the builder here to make it a compile error if we miss
+        // enabling a field if a new one is added.
+        Self {
+            refresh_kind: None,
+            name: true,
+            os_version: true,
+            user: true,
+            memory: true,
+            cpu_vendor: true,
+            cpu_core_count: true,
+            cpu_name: true,
+            cpu_brand: true,
+            cpu_frequency: true,
+
+            #[cfg(test)]
+            fail_pid: false,
+        }
     }
 }
 
@@ -281,7 +280,7 @@ impl Sysinfo {
         }
     }
 
-    fn add_sysinfo_os_verison(
+    fn add_sysinfo_os_version(
         &self,
         _system: &System,
         idempotent: bool,
@@ -542,7 +541,7 @@ impl AddEntries for Sysinfo {
             let system = Self::setup_system(self.refresh_kind);
 
             self.add_sysinfo_name(&system, idempotent, cargo_rustc_env, cargo_warning);
-            self.add_sysinfo_os_verison(&system, idempotent, cargo_rustc_env, cargo_warning);
+            self.add_sysinfo_os_version(&system, idempotent, cargo_rustc_env, cargo_warning);
             self.add_sysinfo_user(&system, idempotent, cargo_rustc_env, cargo_warning);
             self.add_sysinfo_total_memory(&system, idempotent, cargo_rustc_env, cargo_warning);
             self.add_sysinfo_cpu_vendor(&system, idempotent, cargo_rustc_env, cargo_warning);
@@ -570,7 +569,7 @@ impl AddEntries for Sysinfo {
 
 #[cfg(test)]
 mod test {
-    use super::{Sysinfo, SysinfoBuilder};
+    use super::Sysinfo;
     use crate::Emitter;
     use anyhow::Result;
     use serial_test::serial;
@@ -586,7 +585,7 @@ mod test {
     #[serial]
     #[allow(clippy::clone_on_copy, clippy::redundant_clone)]
     fn si_clone_works() -> Result<()> {
-        let si = SysinfoBuilder::all_sysinfo()?;
+        let si = Sysinfo::all_sysinfo();
         let another = si.clone();
         assert_eq!(another, si);
         Ok(())
@@ -595,7 +594,7 @@ mod test {
     #[test]
     #[serial]
     fn si_debug_works() -> Result<()> {
-        let si = SysinfoBuilder::all_sysinfo()?;
+        let si = Sysinfo::all_sysinfo();
         let mut buf = vec![];
         write!(buf, "{si:?}")?;
         assert!(!buf.is_empty());
@@ -605,7 +604,7 @@ mod test {
     #[test]
     #[serial]
     fn si_default() -> Result<()> {
-        let si = SysinfoBuilder::default().build()?;
+        let si = Sysinfo::builder().build();
         let emitter = Emitter::default().add_instructions(&si)?.test_emit();
         assert_eq!(0, emitter.cargo_rustc_env_map().len());
         assert_eq!(0, count_idempotent(emitter.cargo_rustc_env_map()));
@@ -616,7 +615,7 @@ mod test {
     #[test]
     #[serial]
     fn sysinfo_all_idempotent() -> Result<()> {
-        let si = SysinfoBuilder::all_sysinfo()?;
+        let si = Sysinfo::all_sysinfo();
         let config = Emitter::default()
             .idempotent()
             .add_instructions(&si)?
@@ -633,7 +632,7 @@ mod test {
     #[test]
     #[serial]
     fn sysinfo_all() -> Result<()> {
-        let si = SysinfoBuilder::all_sysinfo()?;
+        let si = Sysinfo::all_sysinfo();
         let config = Emitter::default().add_instructions(&si)?.test_emit();
         assert_eq!(SYSINFO_COUNT, config.cargo_rustc_env_map().len());
         assert_eq!(IDEM_COUNT, count_idempotent(config.cargo_rustc_env_map()));
@@ -644,7 +643,7 @@ mod test {
     #[test]
     #[serial]
     fn sysinfo_name() -> Result<()> {
-        let si = SysinfoBuilder::default().name(true).build()?;
+        let si = Sysinfo::builder().name(true).build();
         let config = Emitter::default().add_instructions(&si)?.test_emit();
         assert_eq!(1, config.cargo_rustc_env_map().len());
         assert_eq!(IDEM_COUNT, count_idempotent(config.cargo_rustc_env_map()));
@@ -655,7 +654,7 @@ mod test {
     #[test]
     #[serial]
     fn sysinfo_os_version() -> Result<()> {
-        let si = SysinfoBuilder::default().os_version(true).build()?;
+        let si = Sysinfo::builder().os_version(true).build();
         let config = Emitter::default().add_instructions(&si)?.test_emit();
         assert_eq!(1, config.cargo_rustc_env_map().len());
         assert_eq!(IDEM_COUNT, count_idempotent(config.cargo_rustc_env_map()));
@@ -666,7 +665,7 @@ mod test {
     #[test]
     #[serial]
     fn sysinfo_user() -> Result<()> {
-        let si = SysinfoBuilder::default().user(true).build()?;
+        let si = Sysinfo::builder().user(true).build();
         let config = Emitter::default().add_instructions(&si)?.test_emit();
         assert_eq!(1, config.cargo_rustc_env_map().len());
         assert_eq!(IDEM_COUNT, count_idempotent(config.cargo_rustc_env_map()));
@@ -677,7 +676,7 @@ mod test {
     #[test]
     #[serial]
     fn sysinfo_memory() -> Result<()> {
-        let si = SysinfoBuilder::default().memory(true).build()?;
+        let si = Sysinfo::builder().memory(true).build();
         let config = Emitter::default().add_instructions(&si)?.test_emit();
         assert_eq!(1, config.cargo_rustc_env_map().len());
         assert_eq!(IDEM_COUNT, count_idempotent(config.cargo_rustc_env_map()));
@@ -688,7 +687,7 @@ mod test {
     #[test]
     #[serial]
     fn sysinfo_cpu_vendor() -> Result<()> {
-        let si = SysinfoBuilder::default().cpu_vendor(true).build()?;
+        let si = Sysinfo::builder().cpu_vendor(true).build();
         let config = Emitter::default().add_instructions(&si)?.test_emit();
         assert_eq!(1, config.cargo_rustc_env_map().len());
         assert_eq!(IDEM_COUNT, count_idempotent(config.cargo_rustc_env_map()));
@@ -699,7 +698,7 @@ mod test {
     #[test]
     #[serial]
     fn sysinfo_cpu_core_count() -> Result<()> {
-        let si = SysinfoBuilder::default().cpu_core_count(true).build()?;
+        let si = Sysinfo::builder().cpu_core_count(true).build();
         let config = Emitter::default().add_instructions(&si)?.test_emit();
         assert_eq!(1, config.cargo_rustc_env_map().len());
         assert_eq!(IDEM_COUNT, count_idempotent(config.cargo_rustc_env_map()));
@@ -710,7 +709,7 @@ mod test {
     #[test]
     #[serial]
     fn sysinfo_cpu_name() -> Result<()> {
-        let si = SysinfoBuilder::default().cpu_name(true).build()?;
+        let si = Sysinfo::builder().cpu_name(true).build();
         let config = Emitter::default().add_instructions(&si)?.test_emit();
         assert_eq!(1, config.cargo_rustc_env_map().len());
         assert_eq!(IDEM_COUNT, count_idempotent(config.cargo_rustc_env_map()));
@@ -721,7 +720,7 @@ mod test {
     #[test]
     #[serial]
     fn sysinfo_cpu_brand() -> Result<()> {
-        let si = SysinfoBuilder::default().cpu_brand(true).build()?;
+        let si = Sysinfo::builder().cpu_brand(true).build();
         let config = Emitter::default().add_instructions(&si)?.test_emit();
         assert_eq!(1, config.cargo_rustc_env_map().len());
         assert_eq!(IDEM_COUNT, count_idempotent(config.cargo_rustc_env_map()));
@@ -732,7 +731,7 @@ mod test {
     #[test]
     #[serial]
     fn sysinfo_cpu_frequency() -> Result<()> {
-        let si = SysinfoBuilder::default().cpu_frequency(true).build()?;
+        let si = Sysinfo::builder().cpu_frequency(true).build();
         let config = Emitter::default().add_instructions(&si)?.test_emit();
         assert_eq!(1, config.cargo_rustc_env_map().len());
         assert_eq!(IDEM_COUNT, count_idempotent(config.cargo_rustc_env_map()));
@@ -747,10 +746,10 @@ mod test {
         let cpu_refresh_kind = CpuRefreshKind::everything()
             .without_cpu_usage()
             .without_frequency();
-        let si = SysinfoBuilder::default()
-            .refresh_kind(Some(refresh_kind.with_cpu(cpu_refresh_kind)))
+        let si = Sysinfo::builder()
+            .refresh_kind(refresh_kind.with_cpu(cpu_refresh_kind))
             .cpu_brand(true)
-            .build()?;
+            .build();
         let config = Emitter::default().add_instructions(&si)?.test_emit();
         assert_eq!(1, config.cargo_rustc_env_map().len());
         assert_eq!(IDEM_COUNT, count_idempotent(config.cargo_rustc_env_map()));
@@ -797,7 +796,7 @@ mod test {
     #[test]
     #[serial_test::serial]
     fn pid_lookup_fails() -> Result<()> {
-        let mut si = SysinfoBuilder::all_sysinfo()?;
+        let mut si = Sysinfo::all_sysinfo();
         let _ = si.fail_pid();
         let emitter = Emitter::default().add_instructions(&si)?.test_emit();
         assert_eq!(SYSINFO_COUNT, emitter.cargo_rustc_env_map().len());
@@ -812,7 +811,7 @@ mod test {
         with_var("VERGEN_SYSINFO_NAME", Some("this is a bad date"), || {
             let result = || -> Result<()> {
                 let mut stdout_buf = vec![];
-                let si = SysinfoBuilder::all_sysinfo()?;
+                let si = Sysinfo::all_sysinfo();
                 let _failed = Emitter::default()
                     .add_instructions(&si)?
                     .emit_to(&mut stdout_buf)?;
@@ -833,7 +832,7 @@ mod test {
             || {
                 let result = || -> Result<()> {
                     let mut stdout_buf = vec![];
-                    let si = SysinfoBuilder::all_sysinfo()?;
+                    let si = Sysinfo::all_sysinfo();
                     let _failed = Emitter::default()
                         .add_instructions(&si)?
                         .emit_to(&mut stdout_buf)?;
@@ -853,7 +852,7 @@ mod test {
         with_var("VERGEN_SYSINFO_USER", Some("this is a bad date"), || {
             let result = || -> Result<()> {
                 let mut stdout_buf = vec![];
-                let si = SysinfoBuilder::all_sysinfo()?;
+                let si = Sysinfo::all_sysinfo();
                 let _failed = Emitter::default()
                     .add_instructions(&si)?
                     .emit_to(&mut stdout_buf)?;
@@ -874,7 +873,7 @@ mod test {
             || {
                 let result = || -> Result<()> {
                     let mut stdout_buf = vec![];
-                    let si = SysinfoBuilder::all_sysinfo()?;
+                    let si = Sysinfo::all_sysinfo();
                     let _failed = Emitter::default()
                         .add_instructions(&si)?
                         .emit_to(&mut stdout_buf)?;
@@ -898,7 +897,7 @@ mod test {
             || {
                 let result = || -> Result<()> {
                     let mut stdout_buf = vec![];
-                    let si = SysinfoBuilder::all_sysinfo()?;
+                    let si = Sysinfo::all_sysinfo();
                     let _failed = Emitter::default()
                         .add_instructions(&si)?
                         .emit_to(&mut stdout_buf)?;
@@ -921,7 +920,7 @@ mod test {
             || {
                 let result = || -> Result<()> {
                     let mut stdout_buf = vec![];
-                    let si = SysinfoBuilder::all_sysinfo()?;
+                    let si = Sysinfo::all_sysinfo();
                     let _failed = Emitter::default()
                         .add_instructions(&si)?
                         .emit_to(&mut stdout_buf)?;
@@ -945,7 +944,7 @@ mod test {
             || {
                 let result = || -> Result<()> {
                     let mut stdout_buf = vec![];
-                    let si = SysinfoBuilder::all_sysinfo()?;
+                    let si = Sysinfo::all_sysinfo();
                     let _failed = Emitter::default()
                         .add_instructions(&si)?
                         .emit_to(&mut stdout_buf)?;
@@ -968,7 +967,7 @@ mod test {
             || {
                 let result = || -> Result<()> {
                     let mut stdout_buf = vec![];
-                    let si = SysinfoBuilder::all_sysinfo()?;
+                    let si = Sysinfo::all_sysinfo();
                     let _failed = Emitter::default()
                         .add_instructions(&si)?
                         .emit_to(&mut stdout_buf)?;
@@ -991,7 +990,7 @@ mod test {
             || {
                 let result = || -> Result<()> {
                     let mut stdout_buf = vec![];
-                    let si = SysinfoBuilder::all_sysinfo()?;
+                    let si = Sysinfo::all_sysinfo();
                     let _failed = Emitter::default()
                         .add_instructions(&si)?
                         .emit_to(&mut stdout_buf)?;

--- a/vergen/src/lib.rs
+++ b/vergen/src/lib.rs
@@ -131,7 +131,7 @@
 #![cfg_attr(
     feature = "build",
     doc = r"// NOTE: This will output only the instructions specified.
-// NOTE: See the specific builder documentation for configuration options. 
+// NOTE: See the specific builder documentation for configuration options.
 let build = BuildBuilder::default().build_timestamp(true).build()?;"
 )]
 #![cfg_attr(
@@ -186,8 +186,8 @@ let build = BuildBuilder::default().build_timestamp(true).build()?;"
 //! ```
 //!
 //! ## Features
-//! `vergen` has four main feature toggles allowing you to customize your output. No features are enabled by default.  
-//! You **must** specifically enable the features you wish to use.  
+//! `vergen` has four main feature toggles allowing you to customize your output. No features are enabled by default.
+//! You **must** specifically enable the features you wish to use.
 #![cfg_attr(
     feature = "emit_and_set",
     doc = r"There is also a toggle for the [`emit_and_set`](Emitter::emit_and_set) function.  This version of emit will also set the instructions you requests as environment variables for use in `build.rs`"
@@ -220,7 +220,7 @@ let build = BuildBuilder::default().build_timestamp(true).build()?;"
 //! ## Goals
 //! I initially wrote `vergen` (**ver**sion **gen**erator, so original) so I could embed a some git information in my
 //! personal projects.  Now, usage has grown to the point that `vergen` needs to fit better in the rust ecosystem.
-//!   
+//!
 //! The current goals are as follows:
 //!
 //! #### Minimize the tool footprint
@@ -498,7 +498,7 @@ mod feature;
     feature = "rustc",
     feature = "si"
 )))]
-use {anyhow as _, derive_builder as _};
+use {anyhow as _, bon as _};
 #[cfg(test)]
 use {lazy_static as _, regex as _, serial_test as _, temp_env as _, test_util as _};
 

--- a/vergen/src/lib.rs
+++ b/vergen/src/lib.rs
@@ -55,20 +55,20 @@
 //! ```
 //! # use anyhow::Result;
 //! # use vergen::Emitter;
-#![cfg_attr(feature = "build", doc = r"# use vergen::BuildBuilder;")]
-#![cfg_attr(feature = "cargo", doc = r"# use vergen::CargoBuilder;")]
-#![cfg_attr(feature = "rustc", doc = r"# use vergen::RustcBuilder;")]
-#![cfg_attr(feature = "si", doc = r"# use vergen::SysinfoBuilder;")]
+#![cfg_attr(feature = "build", doc = r"# use vergen::Build;")]
+#![cfg_attr(feature = "cargo", doc = r"# use vergen::Cargo;")]
+#![cfg_attr(feature = "rustc", doc = r"# use vergen::Rustc;")]
+#![cfg_attr(feature = "si", doc = r"# use vergen::Sysinfo;")]
 #![cfg_attr(feature = "cargo", doc = r"# use test_util::with_cargo_vars;")]
 //! #
 //! # pub fn main() -> Result<()> {
 #![cfg_attr(feature = "cargo", doc = r"# let result = with_cargo_vars(|| {")]
 //! // NOTE: This will output everything, and requires all features enabled.
 //! // NOTE: See the specific builder documentation for configuration options.
-#![cfg_attr(feature = "build", doc = r"let build = BuildBuilder::all_build()?;")]
-#![cfg_attr(feature = "cargo", doc = r"let cargo = CargoBuilder::all_cargo()?;")]
-#![cfg_attr(feature = "rustc", doc = r"let rustc = RustcBuilder::all_rustc()?;")]
-#![cfg_attr(feature = "si", doc = r"let si = SysinfoBuilder::all_sysinfo()?;")]
+#![cfg_attr(feature = "build", doc = r"let build = Build::all_build();")]
+#![cfg_attr(feature = "cargo", doc = r"let cargo = Cargo::all_cargo();")]
+#![cfg_attr(feature = "rustc", doc = r"let rustc = Rustc::all_rustc();")]
+#![cfg_attr(feature = "si", doc = r"let si = Sysinfo::all_sysinfo();")]
 //!
 //! Emitter::default()
 #![cfg_attr(feature = "build", doc = r"    .add_instructions(&build)?")]
@@ -120,10 +120,10 @@
 //! ```
 //! # use anyhow::Result;
 //! # use vergen::Emitter;
-#![cfg_attr(feature = "build", doc = r"# use vergen::BuildBuilder;")]
-#![cfg_attr(feature = "cargo", doc = r"# use vergen::CargoBuilder;")]
-#![cfg_attr(feature = "rustc", doc = r"# use vergen::RustcBuilder;")]
-#![cfg_attr(feature = "si", doc = r"# use vergen::SysinfoBuilder;")]
+#![cfg_attr(feature = "build", doc = r"# use vergen::Build;")]
+#![cfg_attr(feature = "cargo", doc = r"# use vergen::Cargo;")]
+#![cfg_attr(feature = "rustc", doc = r"# use vergen::Rustc;")]
+#![cfg_attr(feature = "si", doc = r"# use vergen::Sysinfo;")]
 #![cfg_attr(feature = "cargo", doc = r"# use test_util::with_cargo_vars;")]
 //! #
 //! # pub fn main() -> Result<()> {
@@ -132,19 +132,19 @@
     feature = "build",
     doc = r"// NOTE: This will output only the instructions specified.
 // NOTE: See the specific builder documentation for configuration options.
-let build = BuildBuilder::default().build_timestamp(true).build()?;"
+let build = Build::builder().build_timestamp(true).build();"
 )]
 #![cfg_attr(
     feature = "cargo",
-    doc = r"let cargo = CargoBuilder::default().opt_level(true).build()?;"
+    doc = r"let cargo = Cargo::builder().opt_level(true).build();"
 )]
 #![cfg_attr(
     feature = "rustc",
-    doc = r"let rustc = RustcBuilder::default().semver(true).build()?;"
+    doc = r"let rustc = Rustc::builder().semver(true).build();"
 )]
 #![cfg_attr(
     feature = "si",
-    doc = r"let si = SysinfoBuilder::default().cpu_core_count(true).build()?;"
+    doc = r"let si = Sysinfo::builder().cpu_core_count(true).build();"
 )]
 //!
 //! Emitter::default()

--- a/vergen/tests/build_output.rs
+++ b/vergen/tests/build_output.rs
@@ -6,7 +6,7 @@ mod test_build {
     use serial_test::serial;
     use vergen::Build;
     use vergen::Emitter;
-    use vergen_lib::{CustomInsGen, CustomInsGenBuilder};
+    use vergen_lib::CustomInsGen;
 
     lazy_static! {
         static ref DATE_RE_STR: &'static str =
@@ -125,7 +125,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
     #[serial]
     fn build_all_with_custom_fail() -> Result<()> {
         let build = Build::all_build();
-        let cust_gen = CustomInsGenBuilder::default().fail(true).build()?;
+        let cust_gen = CustomInsGen::builder().fail(true).build();
         assert!(Emitter::new()
             .fail_on_error()
             .add_instructions(&build)?
@@ -139,7 +139,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
     fn build_all_with_custom_default() -> Result<()> {
         let mut stdout_buf = vec![];
         let build = Build::all_build();
-        let cust_gen = CustomInsGenBuilder::default().fail(true).build()?;
+        let cust_gen = CustomInsGen::builder().fail(true).build();
         Emitter::new()
             .add_instructions(&build)?
             .add_custom_instructions(&cust_gen)?

--- a/vergen/tests/build_output.rs
+++ b/vergen/tests/build_output.rs
@@ -4,7 +4,7 @@ mod test_build {
     use lazy_static::lazy_static;
     use regex::Regex;
     use serial_test::serial;
-    use vergen::BuildBuilder;
+    use vergen::Build;
     use vergen::Emitter;
     use vergen_lib::{CustomInsGen, CustomInsGenBuilder};
 
@@ -81,7 +81,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
     #[serial]
     fn build_all_output() -> Result<()> {
         let mut stdout_buf = vec![];
-        let build = BuildBuilder::all_build()?;
+        let build = Build::all_build();
         Emitter::new()
             .add_instructions(&build)?
             .emit_to(&mut stdout_buf)?;
@@ -94,7 +94,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
     #[serial]
     fn build_all_with_custom_output() -> Result<()> {
         let mut stdout_buf = vec![];
-        let build = BuildBuilder::all_build()?;
+        let build = Build::all_build();
         let cust_gen = CustomInsGen::default();
         Emitter::new()
             .add_instructions(&build)?
@@ -109,7 +109,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
     #[serial]
     fn build_all_with_custom_idempotent_output() -> Result<()> {
         let mut stdout_buf = vec![];
-        let build = BuildBuilder::all_build()?;
+        let build = Build::all_build();
         let cust_gen = CustomInsGen::default();
         Emitter::new()
             .idempotent()
@@ -124,7 +124,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
     #[test]
     #[serial]
     fn build_all_with_custom_fail() -> Result<()> {
-        let build = BuildBuilder::all_build()?;
+        let build = Build::all_build();
         let cust_gen = CustomInsGenBuilder::default().fail(true).build()?;
         assert!(Emitter::new()
             .fail_on_error()
@@ -138,7 +138,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
     #[serial]
     fn build_all_with_custom_default() -> Result<()> {
         let mut stdout_buf = vec![];
-        let build = BuildBuilder::all_build()?;
+        let build = Build::all_build();
         let cust_gen = CustomInsGenBuilder::default().fail(true).build()?;
         Emitter::new()
             .add_instructions(&build)?
@@ -155,11 +155,11 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
         temp_env::with_var("SOURCE_DATE_EPOCH", Some("1671809360"), || {
             let result = || -> Result<()> {
                 let mut stdout_buf = vec![];
-                let build = BuildBuilder::default()
+                let build = Build::builder()
                     .build_date(true)
                     .build_timestamp(true)
                     .use_local(true)
-                    .build()?;
+                    .build();
                 let result = Emitter::new()
                     .add_instructions(&build)?
                     .fail_on_error()
@@ -180,7 +180,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
         temp_env::with_var_unset("SOURCE_DATE_EPOCH", || {
             let result = || -> Result<()> {
                 let mut stdout_buf = vec![];
-                let build = BuildBuilder::all_build()?;
+                let build = Build::all_build();
                 Emitter::new()
                     .idempotent()
                     .add_instructions(&build)?
@@ -200,7 +200,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
         temp_env::with_var_unset("SOURCE_DATE_EPOCH", || {
             let result = || -> Result<()> {
                 let mut stdout_buf = vec![];
-                let build = BuildBuilder::all_build()?;
+                let build = Build::all_build();
                 Emitter::new()
                     .idempotent()
                     .custom_build_rs("a/custom_build.rs")
@@ -221,7 +221,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
         temp_env::with_var_unset("SOURCE_DATE_EPOCH", || {
             let result = || -> Result<()> {
                 let mut stdout_buf = vec![];
-                let build = BuildBuilder::all_build()?;
+                let build = Build::all_build();
                 Emitter::new()
                     .idempotent()
                     .quiet()
@@ -242,7 +242,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
         temp_env::with_var("SOURCE_DATE_EPOCH", Some("1671809360"), || {
             let result = || -> Result<()> {
                 let mut stdout_buf = vec![];
-                let build = BuildBuilder::all_build()?;
+                let build = Build::all_build();
                 Emitter::new()
                     .add_instructions(&build)?
                     .emit_to(&mut stdout_buf)?;

--- a/vergen/tests/cargo_output.rs
+++ b/vergen/tests/cargo_output.rs
@@ -5,7 +5,7 @@ mod test_cargo {
     use regex::Regex;
     use serial_test::serial;
     use test_util::with_cargo_vars;
-    use vergen::CargoBuilder;
+    use vergen::Cargo;
     use vergen::Emitter;
 
     lazy_static! {
@@ -55,7 +55,7 @@ mod test_cargo {
     fn cargo_all_output() {
         let result = with_cargo_vars(|| {
             let mut stdout_buf = vec![];
-            let cargo = CargoBuilder::all_cargo()?;
+            let cargo = Cargo::all_cargo();
             Emitter::default()
                 .add_instructions(&cargo)?
                 .emit_to(&mut stdout_buf)?;
@@ -71,7 +71,7 @@ mod test_cargo {
     fn cargo_all_idempotent_output() {
         let result = with_cargo_vars(|| {
             let mut stdout_buf = vec![];
-            let cargo = CargoBuilder::all_cargo()?;
+            let cargo = Cargo::all_cargo();
             Emitter::default()
                 .idempotent()
                 .add_instructions(&cargo)?
@@ -88,7 +88,7 @@ mod test_cargo {
     fn cargo_all_name_filter_none_output() {
         let result = with_cargo_vars(|| {
             let mut stdout_buf = vec![];
-            let mut cargo = CargoBuilder::all_cargo()?;
+            let mut cargo = Cargo::all_cargo();
             cargo.set_name_filter(Some("blah"));
             Emitter::default()
                 .add_instructions(&cargo)?
@@ -105,7 +105,7 @@ mod test_cargo {
     fn cargo_all_name_filter_some_output() {
         let result = with_cargo_vars(|| {
             let mut stdout_buf = vec![];
-            let mut cargo = CargoBuilder::all_cargo()?;
+            let mut cargo = Cargo::all_cargo();
             cargo.set_name_filter(Some("anyhow"));
             Emitter::default()
                 .add_instructions(&cargo)?
@@ -123,7 +123,7 @@ mod test_cargo {
     fn cargo_all_dep_kind_filter_output() {
         let result = with_cargo_vars(|| {
             let mut stdout_buf = vec![];
-            let mut cargo = CargoBuilder::all_cargo()?;
+            let mut cargo = Cargo::all_cargo();
             cargo.set_dep_kind_filter(Some(DependencyKind::Build));
             Emitter::default()
                 .add_instructions(&cargo)?
@@ -141,7 +141,7 @@ mod test_cargo {
     fn cargo_all_dep_kind_filter_with_name_filter_output() {
         let result = with_cargo_vars(|| {
             let mut stdout_buf = vec![];
-            let mut cargo = CargoBuilder::all_cargo()?;
+            let mut cargo = Cargo::all_cargo();
             cargo.set_dep_kind_filter(Some(DependencyKind::Development));
             cargo.set_name_filter(Some("regex"));
             Emitter::default()

--- a/vergen/tests/rustc_output.rs
+++ b/vergen/tests/rustc_output.rs
@@ -3,7 +3,7 @@ mod test_rustc {
     use anyhow::Result;
     use lazy_static::lazy_static;
     use regex::Regex;
-    use vergen::{Emitter, RustcBuilder};
+    use vergen::{Emitter, Rustc};
 
     lazy_static! {
         static ref RUSTC_CHANNEL_RE_STR: &'static str = r"cargo:rustc-env=VERGEN_RUSTC_CHANNEL=.*";
@@ -32,7 +32,7 @@ mod test_rustc {
     #[test]
     fn rustc_all_output() -> Result<()> {
         let mut stdout_buf = vec![];
-        let rustc = RustcBuilder::all_rustc()?;
+        let rustc = Rustc::all_rustc();
         Emitter::default()
             .add_instructions(&rustc)?
             .emit_to(&mut stdout_buf)?;
@@ -44,7 +44,7 @@ mod test_rustc {
     #[test]
     fn rustc_all_idempotent_output() -> Result<()> {
         let mut stdout_buf = vec![];
-        let rustc = RustcBuilder::all_rustc()?;
+        let rustc = Rustc::all_rustc();
         Emitter::default()
             .idempotent()
             .add_instructions(&rustc)?

--- a/vergen/tests/sysinfo_output.rs
+++ b/vergen/tests/sysinfo_output.rs
@@ -4,7 +4,7 @@ mod test_sysinfo {
     use lazy_static::lazy_static;
     use regex::Regex;
     use serial_test::serial;
-    use vergen::{Emitter, SysinfoBuilder};
+    use vergen::{Emitter, Sysinfo};
 
     lazy_static! {
         static ref NAME_RE_STR: &'static str = r"cargo:rustc-env=VERGEN_SYSINFO_NAME=.*";
@@ -84,7 +84,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
     #[serial]
     fn sysinfo_all_output() -> Result<()> {
         let mut stdout_buf = vec![];
-        let si = SysinfoBuilder::all_sysinfo()?;
+        let si = Sysinfo::all_sysinfo();
         Emitter::default()
             .add_instructions(&si)?
             .emit_to(&mut stdout_buf)?;
@@ -96,7 +96,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
     #[test]
     fn sysinfo_all_idempotent_output() -> Result<()> {
         let mut stdout_buf = vec![];
-        let si = SysinfoBuilder::all_sysinfo()?;
+        let si = Sysinfo::all_sysinfo();
         Emitter::default()
             .idempotent()
             .add_instructions(&si)?
@@ -109,7 +109,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
     #[test]
     fn sysinfo_all_idempotent_quiet_output() -> Result<()> {
         let mut stdout_buf = vec![];
-        let si = SysinfoBuilder::all_sysinfo()?;
+        let si = Sysinfo::all_sysinfo();
         Emitter::default()
             .idempotent()
             .quiet()


### PR DESCRIPTION
Closes #372. The diff is big because basically all tests use builders, so I had to do a lot of boilerplate changes to the builder syntax. Examples of changes:

```rust
GitBuilder::deault().build()?;
// vvv
Git::builder().build();
```

I also changed the `all_*()` methods to be part of the type itself instead of the builder struct, because they just return the type itself directly, and now that builders are ment to be created with `T::builder()` it's easier to call `T::all_*` when `T` is already imported into scope.

```rust
GitBuilder::all_git();
// vvv
Git::all_git();
```

Also builders moved from by-reference to by-value `self`, because `bon` generates a type-state-based builder that changes its type on every setter call.

For some methods like `TBuilder::all(&mut Self)` I had to do a change `all(self) -> Self)` and that this method can be only called at the beginning of the builder method call chain. For example `T::builder().all().foo().build()` works, while this doesn't compile: `T::builder().foo().all().build()`, because `.all()` is only available at the start.