### PR TITLE
gitcl: log output of failed `git` commands.

### DIFF
--- a/vergen-gitcl/src/gitcl/mod.rs
+++ b/vergen-gitcl/src/gitcl/mod.rs
@@ -517,7 +517,15 @@ impl Gitcl {
         _ = cmd.arg(command);
         _ = cmd.stdout(Stdio::piped());
         _ = cmd.stderr(Stdio::piped());
-        Ok(cmd.output()?)
+
+        let output = cmd.output()?;
+        if !output.status.success() {
+            eprintln!("Command failed: `{command}`");
+            eprintln!("--- stdout:\n{}\n", String::from_utf8_lossy(&output.stdout));
+            eprintln!("--- stderr:\n{}\n", String::from_utf8_lossy(&output.stderr));
+        }
+
+        Ok(output)
     }
 
     #[cfg(target_env = "msvc")]
@@ -530,7 +538,15 @@ impl Gitcl {
         _ = cmd.arg(command);
         _ = cmd.stdout(Stdio::piped());
         _ = cmd.stderr(Stdio::piped());
-        Ok(cmd.output()?)
+
+        let output = cmd.output()?;
+        if !output.status.success() {
+            eprintln!("Command failed: `{command}`");
+            eprintln!("--- stdout:\n{}\n", String::from_utf8_lossy(&output.stdout));
+            eprintln!("--- stderr:\n{}\n", String::from_utf8_lossy(&output.stderr));
+        }
+
+        Ok(output)
     }
 
     #[allow(clippy::too_many_lines)]


### PR DESCRIPTION
Hello, and thanks a bunch for this awesome crate!

This patch makes any `git` commands in the `vergen-gitcl` subcrate log their stdout/stderr on failure to provide more background.

### Backstory:

I've just wasted a couple of hours debugging `vergen` telling me that it was "`not within a suitable 'git' worktree!`" when it clearly was...

The root cause of the issue turned out to be that the `rust-build.action` I was using had "dubious ownership" on the `.git` directory, as it is a container-based GitHub action where the `$GITHUB_WORKSPACE` is bind-mounted within the container and thus has differing user IDs.

The effect of this was that some `git` subcommands (most notably `rev-parse`) would error out like so:

```
$ git rev-parse --is-inside-work-tree
fatal: detected dubious ownership in repository at '/github/workspace'
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
```

While `vergen` would only output :

```
...
  --- stderr
  Error: not within a suitable 'git' worktree!
```

I have [proposed a fix on the rust-build action's side](https://github.com/rust-build/rust-build.action/pull/103) but had `vergen` just exposed the stderr of the `git rev-parse` command to me from the get-go, it would have saved me hours of debugging (reproducing the setup with a container-based GitHub action is tedious to say the least).

### Fix notes.

I've simply went with manually-formatted `eprintln!()` statements in the `run_cmd()` method used throughout the rest of the code to log any `git` command failures since I don't consider adding a whole logging crate tree necessary, but I could if it's deemed it is. 