### PR TITLE
Bump git2 to 0.20.1

### DIFF
--- a/vergen-git2/Cargo.toml
+++ b/vergen-git2/Cargo.toml
@@ -35,7 +35,7 @@ si = ["vergen/si"]
 [dependencies]
 anyhow = "1.0.95"
 derive_builder = "0.20.2"
-git2-rs = { version = "0.20.0", package = "git2", default-features = false }
+git2-rs = { version = "0.20.1", package = "git2", default-features = false }
 time = { version = "0.3.37", features = [
     "formatting",
     "local-offset",


### PR DESCRIPTION
Due to changes to the Rust standard library, the `vergen-git2` crate fails to link on nightly Windows targets (see e.g. [rsonpath/#704](https://github.com/rsonquery/rsonpath/pull/704)).

The issue originates in the `git2-rs` crate and [has been resolved upstream](https://github.com/rust-lang/git2-rs/issues/1142), with the fix included in release v0.20.1.

This PR simply bumps the dependency to include the fix to unblock nightly CI/CD pipelines.