### PR TITLE
prepare `vergen-pretty` release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 
 [workspace.dependencies]
 anyhow = "1.0.99"
-bon = "3.7.1"
+bon = "3.7.2"
 gix = { version = "0.73.0", default-features = false, features = [
     "revision",
     "worktree-mutation",
@@ -24,7 +24,7 @@ regex = { version = "1.11.2" }
 rustversion = "1.0.22"
 serial_test = "3.2.0"
 temp-env = "0.3.6"
-time = { version = "0.3.41", features = [
+time = { version = "0.3.43", features = [
     "formatting",
     "local-offset",
     "parsing",

--- a/vergen-pretty/Cargo.toml
+++ b/vergen-pretty/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.88.0"
 name = "vergen-pretty"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "1.0.2"
+version = "2.0.0"
 
 [package.metadata.cargo-matrix]
 [[package.metadata.cargo-matrix.channel]]
@@ -63,7 +63,7 @@ vergen-gix = { version = "2.0.0-beta.1", path = "../vergen-gix", features = [
 [dev-dependencies]
 regex = { workspace = true }
 serde_json = "1.0.143"
-tracing-subscriber = { version = "0.3.19", features = ["fmt"] }
+tracing-subscriber = { version = "=0.3.19", features = ["fmt"] }
 
 [package.metadata.docs.rs]
 features = ["color", "header", "serde", "trace"]


### PR DESCRIPTION
* Bump `vergen-pretty` release to 2.0 due to breaking API changes.  Will yank 1.0.2 after this finishes.