### PR TITLE
add GIT_DIRTY to docs

### DIFF
--- a/vergen-git2/src/lib.rs
+++ b/vergen-git2/src/lib.rs
@@ -110,6 +110,7 @@
 //! cargo:rustc-env=VERGEN_GIT_COMMIT_MESSAGE=depsup
 //! cargo:rustc-env=VERGEN_GIT_COMMIT_TIMESTAMP=2024-01-30T21:43:43.000000000Z
 //! cargo:rustc-env=VERGEN_GIT_DESCRIBE=0.1.0-beta.1-15-g728e25c
+//! cargo:rustc-env=VERGEN_GIT_DIRTY=false
 //! cargo:rustc-env=VERGEN_GIT_SHA=728e25ca5bb7edbbc505f12b28c66b2b27883cf1
 //! cargo:rustc-env=VERGEN_RUSTC_CHANNEL=nightly
 //! cargo:rustc-env=VERGEN_RUSTC_COMMIT_DATE=2024-01-29

--- a/vergen-gitcl/src/lib.rs
+++ b/vergen-gitcl/src/lib.rs
@@ -110,6 +110,7 @@
 //! cargo:rustc-env=VERGEN_GIT_COMMIT_MESSAGE=depsup
 //! cargo:rustc-env=VERGEN_GIT_COMMIT_TIMESTAMP=2024-01-30T21:43:43.000000000Z
 //! cargo:rustc-env=VERGEN_GIT_DESCRIBE=0.1.0-beta.1-15-g728e25c
+//! cargo:rustc-env=VERGEN_GIT_DIRTY=false
 //! cargo:rustc-env=VERGEN_GIT_SHA=728e25ca5bb7edbbc505f12b28c66b2b27883cf1
 //! cargo:rustc-env=VERGEN_RUSTC_CHANNEL=nightly
 //! cargo:rustc-env=VERGEN_RUSTC_COMMIT_DATE=2024-01-29

--- a/vergen-gix/src/lib.rs
+++ b/vergen-gix/src/lib.rs
@@ -110,6 +110,7 @@
 //! cargo:rustc-env=VERGEN_GIT_COMMIT_MESSAGE=depsup
 //! cargo:rustc-env=VERGEN_GIT_COMMIT_TIMESTAMP=2024-01-30T21:43:43.000000000Z
 //! cargo:rustc-env=VERGEN_GIT_DESCRIBE=0.1.0-beta.1-15-g728e25c
+//! cargo:rustc-env=VERGEN_GIT_DIRTY=false
 //! cargo:rustc-env=VERGEN_GIT_SHA=728e25ca5bb7edbbc505f12b28c66b2b27883cf1
 //! cargo:rustc-env=VERGEN_RUSTC_CHANNEL=nightly
 //! cargo:rustc-env=VERGEN_RUSTC_COMMIT_DATE=2024-01-29


### PR DESCRIPTION
The `VERGEN_GIT_DIRTY` flag is useful to me, but it wasn't documented, so I wasn't sure if I could use it. After trying it works as I hoped. This makes it clear in the docs.