### PR TITLE
Dependency Updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,14 @@ members = [
 
 [workspace.dependencies]
 anyhow = "1.0.102"
-bon = "3.9.0"
-gix = { version = "0.80.0", default-features = false, features = [
+bon = "3.9.1"
+gix = { version = "0.82.0", default-features = false, features = [
     "revision",
     "worktree-mutation",
     "blocking-network-client",
+    "sha1",
 ] }
-rand = { version = "0.10.0" }
+rand = { version = "0.10.1" }
 regex = { version = "1.12.3" }
 rustversion = "1.0.22"
 serial_test = "3.4.0"

--- a/test_util/Cargo.toml
+++ b/test_util/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.91.1"
 name = "test_util"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "10.0.0-beta.6"
+version = "10.0.0-beta.7"
 
 [package.metadata.cargo-matrix]
 [[package.metadata.cargo-matrix.channel]]
@@ -39,8 +39,3 @@ serial_test = { workspace =  true }
 
 [build-dependencies]
 rustversion = { workspace = true }
-
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = [
-    'cfg(coverage,coverage_nightly)',
-] }

--- a/test_util/src/repo/mod.rs
+++ b/test_util/src/repo/mod.rs
@@ -133,8 +133,8 @@ impl TestRepos {
 
         // Setup the base configuration
         let mut config = repo.config_snapshot_mut();
-        let _old = config.set_raw_value(&"user.name", "Vergen Test")?;
-        let _old = config.set_raw_value(&"user.email", "vergen@blah.com")?;
+        let _old = config.set_raw_value("user.name", "Vergen Test")?;
+        let _old = config.set_raw_value("user.email", "vergen@blah.com")?;
 
         {
             // Create an empty commit with the initial empty tree

--- a/vergen-git2/Cargo.toml
+++ b/vergen-git2/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.91.1"
 name = "vergen-git2"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "10.0.0-beta.6"
+version = "10.0.0-beta.7"
 
 [package.metadata.cargo-matrix]
 [[package.metadata.cargo-matrix.channel]]
@@ -54,8 +54,8 @@ anyhow = { workspace = true }
 bon = { workspace = true }
 git2-rs = { version = "0.20.4", package = "git2", default-features = false }
 time = { workspace = true }
-vergen = { version = "10.0.0-beta.6", path = "../vergen", default-features = false }
-vergen-lib = { version = "10.0.0-beta.6", path = "../vergen-lib", features = [
+vergen = { version = "10.0.0-beta.7", path = "../vergen", default-features = false }
+vergen-lib = { version = "10.0.0-beta.7", path = "../vergen-lib", features = [
     "git",
 ] }
 
@@ -71,8 +71,3 @@ test_util = { path = "../test_util", features = ["repo", "unstable"] }
 [package.metadata.docs.rs]
 features = ["build", "cargo", "emit_and_set", "rustc", "si"]
 rustdoc-args = ["--cfg", "docsrs"]
-
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = [
-    'cfg(coverage,coverage_nightly)',
-] }

--- a/vergen-gitcl/Cargo.toml
+++ b/vergen-gitcl/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.91.1"
 name = "vergen-gitcl"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "10.0.0-beta.6"
+version = "10.0.0-beta.7"
 
 [package.metadata.cargo-matrix]
 [[package.metadata.cargo-matrix.channel]]
@@ -53,8 +53,8 @@ si = ["vergen/si"]
 anyhow = { workspace = true }
 bon = { workspace = true }
 time = { workspace = true }
-vergen = { version = "10.0.0-beta.6", path = "../vergen", default-features = false }
-vergen-lib = { version = "10.0.0-beta.6", path = "../vergen-lib", features = ["git"] }
+vergen = { version = "10.0.0-beta.7", path = "../vergen", default-features = false }
+vergen-lib = { version = "10.0.0-beta.7", path = "../vergen-lib", features = ["git"] }
 
 [build-dependencies]
 rustversion = { workspace = true }
@@ -68,8 +68,3 @@ test_util = { path = "../test_util", features = ["repo", "unstable"] }
 [package.metadata.docs.rs]
 features = ["build", "cargo", "emit_and_set", "rustc", "si"]
 rustdoc-args = ["--cfg", "docsrs"]
-
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = [
-    'cfg(coverage,coverage_nightly)',
-] }

--- a/vergen-gix/Cargo.toml
+++ b/vergen-gix/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.91.1"
 name = "vergen-gix"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "10.0.0-beta.6"
+version = "10.0.0-beta.7"
 
 [package.metadata.cargo-matrix]
 [[package.metadata.cargo-matrix.channel]]
@@ -69,10 +69,11 @@ gix = { workspace = true, features = [
     "interrupt",
     "status",
     "dirwalk",
+    "sha1",
 ] }
 time = { workspace = true }
-vergen = { version = "10.0.0-beta.6", path = "../vergen", default-features = false }
-vergen-lib = { version = "10.0.0-beta.6", path = "../vergen-lib", features = [
+vergen = { version = "10.0.0-beta.7", path = "../vergen", default-features = false }
+vergen-lib = { version = "10.0.0-beta.7", path = "../vergen-lib", features = [
     "git",
 ] }
 
@@ -89,7 +90,3 @@ temp-env = { workspace = true }
 features = ["build", "cargo", "emit_and_set", "rustc", "si"]
 rustdoc-args = ["--cfg", "docsrs"]
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = [
-    'cfg(coverage,coverage_nightly)',
-] }

--- a/vergen-lib/Cargo.toml
+++ b/vergen-lib/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.91.1"
 name = "vergen-lib"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "10.0.0-beta.6"
+version = "10.0.0-beta.7"
 
 [package.metadata.cargo-matrix]
 [[package.metadata.cargo-matrix.channel]]

--- a/vergen-pretty/Cargo.toml
+++ b/vergen-pretty/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.91.1"
 name = "vergen-pretty"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "10.0.0-beta.6"
+version = "10.0.0-beta.7"
 
 [package.metadata.cargo-matrix]
 [[package.metadata.cargo-matrix.channel]]
@@ -45,11 +45,11 @@ __vergen_empty_test = ["vergen-gix", "vergen-gix/unstable"]
 [dependencies]
 anyhow = { workspace = true }
 bon = { workspace = true }
-console = { version = "0.16.2", optional = true }
+console = { version = "0.16.3", optional = true }
 convert_case = "0.11.0"
 rand = { workspace = true, optional = true }
 serde = { version = "1.0.228", features = ["derive"], optional = true }
-rkyv = { version = "0.8", features = ["std"], optional = true }
+rkyv = { version = "0.8.16", features = ["std"], optional = true }
 tracing = { version = "0.1.44", features = [
     "max_level_trace",
     "release_max_level_trace",
@@ -58,7 +58,7 @@ tracing = { version = "0.1.44", features = [
 [build-dependencies]
 anyhow = { workspace = true }
 rustversion = { workspace = true }
-vergen-gix = { version = "10.0.0-beta.6", path = "../vergen-gix", features = [
+vergen-gix = { version = "10.0.0-beta.7", path = "../vergen-gix", features = [
     "build",
     "cargo",
     "rustc",
@@ -68,13 +68,8 @@ vergen-gix = { version = "10.0.0-beta.6", path = "../vergen-gix", features = [
 [dev-dependencies]
 regex = { workspace = true }
 serde_json = "1.0.149"
-tracing-subscriber = { version = "=0.3.19", features = ["fmt"] }
+tracing-subscriber = { version = "0.3.23", features = ["fmt"] }
 
 [package.metadata.docs.rs]
 features = ["color", "header", "rkyv", "serde", "trace"]
 rustdoc-args = ["--cfg", "docsrs"]
-
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = [
-    'cfg(coverage,coverage_nightly)',
-] }

--- a/vergen/Cargo.toml
+++ b/vergen/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.91.1"
 name = "vergen"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "10.0.0-beta.6"
+version = "10.0.0-beta.7"
 
 [package.metadata.cargo-matrix]
 [[package.metadata.cargo-matrix.channel]]
@@ -39,9 +39,9 @@ bon = { workspace = true }
 cargo_metadata = { version = "0.23.1", optional = true }
 regex = { workspace = true, optional = true }
 rustc_version = { version = "0.4.1", optional = true }
-sysinfo = { version = "0.38.3", optional = true }
+sysinfo = { version = "0.38.4", optional = true }
 time = { workspace = true, optional = true }
-vergen-lib = { version = "10.0.0-beta.6", path = "../vergen-lib" }
+vergen-lib = { version = "10.0.0-beta.7", path = "../vergen-lib" }
 
 [build-dependencies]
 rustversion = { workspace = true }
@@ -55,8 +55,3 @@ temp-env = { workspace = true }
 [package.metadata.docs.rs]
 features = ["build", "cargo", "emit_and_set", "rustc", "si"]
 rustdoc-args = ["--cfg", "docsrs"]
-
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = [
-    'cfg(coverage,coverage_nightly)',
-] }


### PR DESCRIPTION
This pull request updates dependencies and version numbers across multiple crates in the workspace, mainly for the next `10.0.0-beta.7` release. It also adds or updates some crate features and removes redundant lint configuration blocks. Additionally, there are minor code cleanups for improved consistency.

**Dependency and version updates:**

* Bump crate versions from `10.0.0-beta.6` to `10.0.0-beta.7` in `vergen`, `vergen-lib`, `vergen-gix`, `vergen-git2`, `vergen-gitcl`, `vergen-pretty`, and `test_util` (`vergen/Cargo.toml`, `vergen-lib/Cargo.toml`, `vergen-gix/Cargo.toml`, `vergen-git2/Cargo.toml`, `vergen-gitcl/Cargo.toml`, `vergen-pretty/Cargo.toml`, `test_util/Cargo.toml`) [[1]](diffhunk://#diff-89e151bdf9749c41c75e1a7a0b1f6cfbca726d7b966ebbe3818b54e56e4dfe3eL14-R14) [[2]](diffhunk://#diff-f73efcb89e912cfa44a7f1d916d015f900b54d6f1175d5e4cfe71a32b82ae88eL14-R14) [[3]](diffhunk://#diff-bfa40c1a7be645f7acf579df74bfed7e1b0a94dd1fd60f6e9bad71dd7b241c61L14-R14) [[4]](diffhunk://#diff-640b03ada891cfa8f1eb3b32a1c6c82f912758520bb4a01f23832614cbeb3f8aL14-R14) [[5]](diffhunk://#diff-4e63b30c782ac16f36dbd4ef1a8e830187f63609999caa1996ad3751e9e2e3f2L14-R14) [[6]](diffhunk://#diff-4decc1473ae6d01f68551d8d63f44cb71d879f6084677d31efc1ac38126e4142L14-R14) [[7]](diffhunk://#diff-02b98eca08c9c45fdbfee60cf70175bc859dccebb8651aaef43ccbd0e31723f8L14-R14).
* Update several dependencies to newer versions, including `bon`, `gix`, `rand`, `sysinfo`, `console`, `rkyv`, and `tracing-subscriber` (`Cargo.toml`, `vergen-pretty/Cargo.toml`, `vergen/Cargo.toml`) [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L16-R23) [[2]](diffhunk://#diff-4decc1473ae6d01f68551d8d63f44cb71d879f6084677d31efc1ac38126e4142L48-R52) [[3]](diffhunk://#diff-89e151bdf9749c41c75e1a7a0b1f6cfbca726d7b966ebbe3818b54e56e4dfe3eL42-R44) [[4]](diffhunk://#diff-4decc1473ae6d01f68551d8d63f44cb71d879f6084677d31efc1ac38126e4142L71-L80).
* Add the `sha1` feature to `gix` dependencies in both workspace and `vergen-gix` (`Cargo.toml`, `vergen-gix/Cargo.toml`) [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L16-R23) [[2]](diffhunk://#diff-bfa40c1a7be645f7acf579df74bfed7e1b0a94dd1fd60f6e9bad71dd7b241c61R72-R76).

**Code and configuration cleanups:**

* Remove redundant `[lints.rust]` blocks related to `unexpected_cfgs` from several `Cargo.toml` files (`vergen/Cargo.toml`, `vergen-gix/Cargo.toml`, `vergen-git2/Cargo.toml`, `vergen-gitcl/Cargo.toml`, `vergen-pretty/Cargo.toml`, `test_util/Cargo.toml`) [[1]](diffhunk://#diff-89e151bdf9749c41c75e1a7a0b1f6cfbca726d7b966ebbe3818b54e56e4dfe3eL58-L62) [[2]](diffhunk://#diff-bfa40c1a7be645f7acf579df74bfed7e1b0a94dd1fd60f6e9bad71dd7b241c61L92-L95) [[3]](diffhunk://#diff-640b03ada891cfa8f1eb3b32a1c6c82f912758520bb4a01f23832614cbeb3f8aL74-L78) [[4]](diffhunk://#diff-4e63b30c782ac16f36dbd4ef1a8e830187f63609999caa1996ad3751e9e2e3f2L71-L75) [[5]](diffhunk://#diff-4decc1473ae6d01f68551d8d63f44cb71d879f6084677d31efc1ac38126e4142L71-L80) [[6]](diffhunk://#diff-02b98eca08c9c45fdbfee60cf70175bc859dccebb8651aaef43ccbd0e31723f8L42-L46).
* Minor code cleanup: Remove unnecessary reference in calls to `set_raw_value` in `test_util/src/repo/mod.rs`.