### PR TITLE
chore: replace `getset` with hand-written getters in `vergen-lib` to avoid `proc-macro-error2`

### DIFF
--- a/vergen-lib/Cargo.toml
+++ b/vergen-lib/Cargo.toml
@@ -41,7 +41,6 @@ si = []
 [dependencies]
 anyhow = { workspace = true }
 bon = { workspace = true }
-getset = "0.1.6"
 
 [build-dependencies]
 rustversion = { workspace = true }

--- a/vergen-lib/src/config.rs
+++ b/vergen-lib/src/config.rs
@@ -7,40 +7,70 @@
 // modified, or distributed except according to those terms.
 
 use bon::Builder;
-use getset::{CopyGetters, Getters};
 
 // Common configuration structs
 
 /// git configuration for the `describe` output
-#[derive(Builder, Clone, Copy, CopyGetters, Debug, Eq, Getters, PartialEq)]
+#[derive(Builder, Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Describe {
     /// Instead of using only the annotated tags, use any tag found in refs/tags namespace.
     #[builder(default = false)]
-    #[getset(get_copy = "pub")]
     tags: bool,
     /// If the working tree has local modification "-dirty" is appended to it.
     #[builder(default = false)]
-    #[getset(get_copy = "pub")]
     dirty: bool,
     /// Only consider tags matching the given glob pattern, excluding the "refs/tags/" prefix.
-    #[getset(get = "pub")]
     match_pattern: Option<&'static str>,
 }
 
+impl Describe {
+    /// Instead of using only the annotated tags, use any tag found in refs/tags namespace.
+    #[must_use]
+    pub fn tags(&self) -> bool {
+        self.tags
+    }
+
+    /// If the working tree has local modification "-dirty" is appended to it.
+    #[must_use]
+    pub fn dirty(&self) -> bool {
+        self.dirty
+    }
+
+    /// Only consider tags matching the given glob pattern, excluding the "refs/tags/" prefix.
+    #[must_use]
+    pub fn match_pattern(&self) -> &Option<&'static str> {
+        &self.match_pattern
+    }
+}
+
 /// git configuration for the `sha` output
-#[derive(Builder, Clone, Copy, CopyGetters, Debug, Eq, PartialEq)]
+#[derive(Builder, Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Sha {
     /// Shortens the object name to a unique prefix
     #[builder(default = false)]
-    #[getset(get_copy = "pub")]
     short: bool,
 }
 
+impl Sha {
+    /// Shortens the object name to a unique prefix
+    #[must_use]
+    pub fn short(&self) -> bool {
+        self.short
+    }
+}
+
 /// git configuration for the `dirty` output
-#[derive(Builder, Clone, Copy, CopyGetters, Debug, Eq, PartialEq)]
+#[derive(Builder, Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Dirty {
     /// Should we include/ignore untracked files in deciding whether the repository is dirty.
     #[builder(default = false)]
-    #[getset(get_copy = "pub")]
     include_untracked: bool,
+}
+
+impl Dirty {
+    /// Should we include/ignore untracked files in deciding whether the repository is dirty.
+    #[must_use]
+    pub fn include_untracked(&self) -> bool {
+        self.include_untracked
+    }
 }


### PR DESCRIPTION
## Motivation

Note: _this PR was created using Amp and manually reviewed_

`getset` depends on `proc-macro-error2`, which currently triggers a future-incompatibility lint that will become a hard error in a future Rust release:

```
warning: the following packages contain code that will be rejected by a future version of Rust: proc-macro-error2 v2.0.1
```

```
warning[E0365]: extern crate `proc_macro` is private and cannot be re-exported
   --> proc-macro-error2-2.0.1/src/lib.rs:494:13
    |
494 |     pub use proc_macro;
    |             ^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out;
              it will become a hard error in a future release!
    = note: for more information, see issue #127909
            <https://github.com/rust-lang/rust/issues/127909>
```

Since `getset` is only used in a single file (`vergen-lib/src/config.rs`) for 5 fields across 3 small structs — all simple `pub` getters — replacing it with hand-written getters lets us drop both `getset` and its transitive `proc-macro-error2` dependency at very low cost.

## Changes

- Drop `getset = "0.1.6"` from `vergen-lib/Cargo.toml`.
- Remove the `use getset::{CopyGetters, Getters};` import, the `CopyGetters`/`Getters` derives, and the `#[getset(...)]` attributes in `vergen-lib/src/config.rs`.
- Add hand-written `impl` blocks with `#[must_use]` getters for `Describe`, `Sha`, and `Dirty`.

## Public API

Preserved exactly. In particular, `Describe::match_pattern` returns `&Option<&'static str>` to match the previous `#[getset(get = "pub")]` behavior.