### PR TITLE
Skip coverage jobs for forked pull requests

### DIFF
--- a/.github/workflows/vergen.yml
+++ b/.github/workflows/vergen.yml
@@ -119,6 +119,7 @@ jobs:
 
   coverage-linux:
     name: 🧱 Coverage (Linux) 🧱
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     needs: test-linux
     uses: rustyhorde/workflows/.github/workflows/coverage.yml@main
     with:
@@ -132,6 +133,7 @@ jobs:
 
   coverage-macos:
     name: 🧱 Coverage (MacOS) 🧱
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     needs: test-macos
     uses: rustyhorde/workflows/.github/workflows/coverage.yml@main
     with:
@@ -145,6 +147,7 @@ jobs:
 
   coverage-windows:
     name: 🧱 Coverage (Wndows) 🧱
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     needs: [test-windows-gnu, test-windows-msvc]
     strategy:
       matrix:
@@ -161,6 +164,7 @@ jobs:
 
   call-vergen-lib:
     name: vergen-lib
+    if: ${{ always() && !failure() && !cancelled() }}
     needs: [coverage-linux, coverage-macos, coverage-windows]
     uses: ./.github/workflows/vergen_lib.yml
     secrets: inherit

--- a/.github/workflows/vergen_git2.yml
+++ b/.github/workflows/vergen_git2.yml
@@ -110,6 +110,7 @@ jobs:
 
   coverage-linux:
     name: 🧱 Coverage (Linux) 🧱
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     needs: test-linux
     uses: rustyhorde/workflows/.github/workflows/coverage.yml@main
     with:
@@ -123,6 +124,7 @@ jobs:
 
   coverage-macos:
     name: 🧱 Coverage (MacOS) 🧱
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     needs: test-macos
     uses: rustyhorde/workflows/.github/workflows/coverage.yml@main
     with:
@@ -136,6 +138,7 @@ jobs:
 
   coverage-windows:
     name: 🧱 Coverage (Wndows) 🧱
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     needs: [test-windows-gnu, test-windows-msvc]
     strategy:
       matrix:

--- a/.github/workflows/vergen_gitcl.yml
+++ b/.github/workflows/vergen_gitcl.yml
@@ -110,6 +110,7 @@ jobs:
 
   coverage-linux:
     name: 🧱 Coverage (Linux) 🧱
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     needs: test-linux
     uses: rustyhorde/workflows/.github/workflows/coverage.yml@main
     with:
@@ -123,6 +124,7 @@ jobs:
 
   coverage-macos:
     name: 🧱 Coverage (MacOS) 🧱
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     needs: test-macos
     uses: rustyhorde/workflows/.github/workflows/coverage.yml@main
     with:
@@ -136,6 +138,7 @@ jobs:
 
   coverage-windows:
     name: 🧱 Coverage (Wndows) 🧱
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     needs: [test-windows-gnu, test-windows-msvc]
     strategy:
       matrix:

--- a/.github/workflows/vergen_gix.yml
+++ b/.github/workflows/vergen_gix.yml
@@ -110,6 +110,7 @@ jobs:
 
   coverage-linux:
     name: 🧱 Coverage (Linux) 🧱
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     needs: test-linux
     uses: rustyhorde/workflows/.github/workflows/coverage.yml@main
     with:
@@ -123,6 +124,7 @@ jobs:
 
   coverage-macos:
     name: 🧱 Coverage (MacOS) 🧱
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     needs: test-macos
     uses: rustyhorde/workflows/.github/workflows/coverage.yml@main
     with:
@@ -136,6 +138,7 @@ jobs:
 
   coverage-windows:
     name: 🧱 Coverage (Wndows) 🧱
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     needs: [test-windows-gnu, test-windows-msvc]
     strategy:
       matrix:

--- a/.github/workflows/vergen_lib.yml
+++ b/.github/workflows/vergen_lib.yml
@@ -110,6 +110,7 @@ jobs:
 
   coverage-linux:
     name: 🧱 Coverage (Linux) 🧱
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     needs: test-linux
     uses: rustyhorde/workflows/.github/workflows/coverage.yml@main
     with:
@@ -123,6 +124,7 @@ jobs:
 
   coverage-macos:
     name: 🧱 Coverage (MacOS) 🧱
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     needs: test-macos
     uses: rustyhorde/workflows/.github/workflows/coverage.yml@main
     with:
@@ -136,6 +138,7 @@ jobs:
 
   coverage-windows:
     name: 🧱 Coverage (Wndows) 🧱
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     needs: [test-windows-gnu, test-windows-msvc]
     strategy:
       matrix:

--- a/.github/workflows/vergen_pretty.yml
+++ b/.github/workflows/vergen_pretty.yml
@@ -110,6 +110,7 @@ jobs:
 
   coverage-linux:
     name: 🧱 Coverage (Linux) 🧱
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     needs: test-linux
     uses: rustyhorde/workflows/.github/workflows/coverage.yml@main
     with:
@@ -123,6 +124,7 @@ jobs:
 
   coverage-macos:
     name: 🧱 Coverage (MacOS) 🧱
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     needs: test-macos
     uses: rustyhorde/workflows/.github/workflows/coverage.yml@main
     with:
@@ -136,6 +138,7 @@ jobs:
 
   coverage-windows:
     name: 🧱 Coverage (Wndows) 🧱
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     needs: [test-windows-gnu, test-windows-msvc]
     strategy:
       matrix:


### PR DESCRIPTION
Coverage workflows require inherited secrets, which are not available to pull requests submitted from forks. Guard each coverage job so it still runs for pushes, scheduled/manual runs, and same-repository pull requests, but skips safely for outside contributors.

Allow the downstream vergen-lib workflow call to continue when coverage jobs are intentionally skipped, while still respecting real failures and cancellations.