### PR TITLE
Prepare release 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Cargo.lock
 .DS_Store
 cobertura.xml
 lcov.info
+CLAUDE.md

--- a/vergen/src/feature/si.rs
+++ b/vergen/src/feature/si.rs
@@ -351,7 +351,7 @@ impl Sysinfo {
     #[cfg(not(test))]
     #[allow(clippy::unused_self)]
     fn get_pid(&self) -> Result<Pid> {
-        get_current_pid().map_err(|e| anyhow!(format!("{e}")))
+        get_current_pid().map_err(|e| anyhow!(e.to_string()))
     }
 
     #[cfg(test)]
@@ -359,7 +359,7 @@ impl Sysinfo {
         if self.fail_pid {
             Err(anyhow!("unable to determine pid"))
         } else {
-            get_current_pid().map_err(|e| anyhow!(format!("{e}")))
+            get_current_pid().map_err(|e| anyhow!(e.to_string()))
         }
     }
 


### PR DESCRIPTION
## Summary

- Replace `format!("{e}")` with `e.to_string()` in `vergen/src/feature/si.rs` (clippy lint fix)

## Test plan

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo matrix -c nightly clippy --all-targets -- -Dwarnings`
- [ ] `cargo matrix test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)