### PR TITLE
(fix): doc versions (#483) and arch-independent hash test (#494)

### DIFF
--- a/vergen-git2/src/lib.rs
+++ b/vergen-git2/src/lib.rs
@@ -45,9 +45,9 @@
 //!
 //! [build-dependencies]
 //! # All features enabled
-//! vergen-git2 = { version = "1.0.0", features = ["build", "cargo", "rustc", "si"] }
+//! vergen-git2 = { version = "10", features = ["build", "cargo", "rustc", "si"] }
 //! # or
-//! vergen-git2 = { version = "1.0.0", features = ["build"] }
+//! vergen-git2 = { version = "10", features = ["build"] }
 //! # if you wish to disable certain features
 //! ```
 //!

--- a/vergen-gitcl/src/lib.rs
+++ b/vergen-gitcl/src/lib.rs
@@ -45,9 +45,9 @@
 //!
 //! [build-dependencies]
 //! # All features enabled
-//! vergen-gitcl = { version = "1.0.0", features = ["build", "cargo", "rustc", "si"] }
+//! vergen-gitcl = { version = "10", features = ["build", "cargo", "rustc", "si"] }
 //! # or
-//! vergen-gitcl = { version = "1.0.0", features = ["build"] }
+//! vergen-gitcl = { version = "10", features = ["build"] }
 //! # if you wish to disable certain features
 //! ```
 //!

--- a/vergen-gix/src/lib.rs
+++ b/vergen-gix/src/lib.rs
@@ -45,9 +45,9 @@
 //!
 //! [build-dependencies]
 //! # All features enabled
-//! vergen-gix = { version = "1.0.0", features = ["build", "cargo", "rustc", "si"] }
+//! vergen-gix = { version = "10", features = ["build", "cargo", "rustc", "si"] }
 //! # or
-//! vergen-gix = { version = "1.0.0", features = ["build"] }
+//! vergen-gix = { version = "10", features = ["build"] }
 //! # if you wish to disable certain features
 //! ```
 //!

--- a/vergen-lib/src/keys.rs
+++ b/vergen-lib/src/keys.rs
@@ -297,9 +297,14 @@ mod test {
 
     #[test]
     fn vergen_key_hash_works() {
-        let mut hasher = DefaultHasher::new();
-        VergenKey::Empty.hash(&mut hasher);
-        assert_eq!(15_130_871_412_783_076_140, hasher.finish());
+        // Assert hashing is deterministic rather than a hard-coded digest: the
+        // derived enum-discriminant hash is pointer-width dependent, so a fixed
+        // value only holds on 64-bit targets (see #494).
+        let mut first = DefaultHasher::new();
+        VergenKey::Empty.hash(&mut first);
+        let mut second = DefaultHasher::new();
+        VergenKey::Empty.hash(&mut second);
+        assert_eq!(first.finish(), second.finish());
     }
 }
 
@@ -349,8 +354,17 @@ mod test {
 
     #[test]
     fn vergen_key_hash_works() {
-        let mut hasher = DefaultHasher::new();
-        VergenKey::BuildDate.hash(&mut hasher);
-        assert_eq!(13_646_096_770_106_105_413, hasher.finish());
+        // Assert hashing is deterministic rather than a hard-coded digest: the
+        // derived enum-discriminant hash is pointer-width dependent, so a fixed
+        // value only holds on 64-bit targets (see #494).
+        let mut first = DefaultHasher::new();
+        VergenKey::BuildDate.hash(&mut first);
+        let mut second = DefaultHasher::new();
+        VergenKey::BuildDate.hash(&mut second);
+        assert_eq!(first.finish(), second.finish());
+
+        let mut other = DefaultHasher::new();
+        VergenKey::CargoDebug.hash(&mut other);
+        assert_ne!(first.finish(), other.finish());
     }
 }

--- a/vergen/src/lib.rs
+++ b/vergen/src/lib.rs
@@ -40,9 +40,9 @@
 //!
 //! [build-dependencies]
 //! # All features enabled
-//! vergen = { version = "9.0.0", features = ["build", "cargo", "rustc", "si"] }
+//! vergen = { version = "10", features = ["build", "cargo", "rustc", "si"] }
 //! # or
-//! vergen = { version = "9.0.0", features = ["build"] }
+//! vergen = { version = "10", features = ["build"] }
 //! # if you wish to disable certain features
 //! ```
 //!


### PR DESCRIPTION
Two small, independent fixes.

## #483 — wrong version in doc install snippets
The rustdoc header examples showed stale versions (`vergen = "9.0.0"`, and the git
crates `"1.0.0"`). Updated all four to the v10 major (`version = "10"`).

## #494 — `vergen_key_hash_works` fails on i386
The test asserted a hard-coded `DefaultHasher::finish()` digest. The derived
enum-discriminant hash is pointer-width dependent, so the magic number only held on
64-bit targets and failed on i386 ([Debian CI](https://ci.debian.net/packages/r/rust-vergen-lib/testing/i386/71477085/)).
Now asserts hashing is deterministic (same key → equal; different key → differs) instead
of pinning a value. `VergenKey`'s `Hash` impl is otherwise unused (the map is `BTreeMap`
keyed by `Ord`), so this is safe.

Closes #483
Closes #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)