### PR TITLE
(feat): raw Unix-seconds timestamps (#444)

### DIFF
--- a/vergen-git2/src/git2/mod.rs
+++ b/vergen-git2/src/git2/mod.rs
@@ -28,8 +28,8 @@ use vergen_lib::{
     Dirty, Sha, VergenKey, add_default_map_entry, add_map_entry,
     constants::{
         GIT_BRANCH_NAME, GIT_COMMIT_AUTHOR_EMAIL, GIT_COMMIT_AUTHOR_NAME, GIT_COMMIT_COUNT,
-        GIT_COMMIT_DATE_NAME, GIT_COMMIT_MESSAGE, GIT_COMMIT_TIMESTAMP_NAME, GIT_DESCRIBE_NAME,
-        GIT_DIRTY_NAME, GIT_SHA_NAME,
+        GIT_COMMIT_DATE_NAME, GIT_COMMIT_MESSAGE, GIT_COMMIT_TIMESTAMP_NAME,
+        GIT_COMMIT_TIMESTAMP_UNIX_NAME, GIT_DESCRIBE_NAME, GIT_DIRTY_NAME, GIT_SHA_NAME,
     },
 };
 #[cfg(feature = "allow_remote")]
@@ -177,6 +177,15 @@ pub struct Git2 {
     ///
     #[builder(default = all)]
     commit_timestamp: bool,
+    /// Emit the commit timestamp of the latest commit as Unix seconds
+    ///
+    /// ```text
+    /// cargo:rustc-env=VERGEN_GIT_COMMIT_TIMESTAMP_UNIX=<SECONDS>
+    /// ```
+    ///
+    /// This is opt-in and is not enabled by [`Git2::all_git`].
+    #[builder(default = false)]
+    commit_timestamp_unix: bool,
     /// Emit the describe output
     ///
     /// ```text
@@ -274,6 +283,7 @@ impl Git2 {
             || self.commit_date
             || self.commit_message
             || self.commit_timestamp
+            || self.commit_timestamp_unix
             || self.describe.is_some()
             || self.sha.is_some()
             || self.dirty.is_some()
@@ -755,7 +765,42 @@ impl Git2 {
         } else {
             self.add_git_timestamp_entry(idempotent, &ts, cargo_rustc_env, cargo_warning)?;
         }
+        if let Ok(_value) = env::var(GIT_COMMIT_TIMESTAMP_UNIX_NAME) {
+            add_default_map_entry(
+                idempotent,
+                VergenKey::GitCommitTimestampUnix,
+                cargo_rustc_env,
+                cargo_warning,
+            );
+        } else {
+            self.add_git_timestamp_unix_entry(idempotent, &ts, cargo_rustc_env, cargo_warning);
+        }
         Ok(())
+    }
+
+    fn add_git_timestamp_unix_entry(
+        &self,
+        idempotent: bool,
+        ts: &OffsetDateTime,
+        cargo_rustc_env: &mut CargoRustcEnvMap,
+        cargo_warning: &mut CargoWarning,
+    ) {
+        if self.commit_timestamp_unix {
+            if idempotent {
+                add_default_map_entry(
+                    idempotent,
+                    VergenKey::GitCommitTimestampUnix,
+                    cargo_rustc_env,
+                    cargo_warning,
+                );
+            } else {
+                add_map_entry(
+                    VergenKey::GitCommitTimestampUnix,
+                    ts.unix_timestamp().to_string(),
+                    cargo_rustc_env,
+                );
+            }
+        }
     }
 
     #[cfg_attr(coverage_nightly, coverage(off))]
@@ -861,6 +906,7 @@ impl AddEntries for Git2 {
         Ok(())
     }
 
+    #[allow(clippy::too_many_lines)]
     fn add_default_entries(
         &self,
         config: &DefaultConfig,
@@ -934,6 +980,14 @@ impl AddEntries for Git2 {
                 add_default_map_entry(
                     *config.idempotent(),
                     VergenKey::GitCommitTimestamp,
+                    cargo_rustc_env_map,
+                    cargo_warning,
+                );
+            }
+            if self.commit_timestamp_unix {
+                add_default_map_entry(
+                    *config.idempotent(),
+                    VergenKey::GitCommitTimestampUnix,
                     cargo_rustc_env_map,
                     cargo_warning,
                 );
@@ -1468,5 +1522,57 @@ mod test {
             "{output}"
         );
         Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn commit_timestamp_unix_works() -> Result<()> {
+        let git2 = Git2::builder().commit_timestamp_unix(true).build();
+        let mut stdout_buf = vec![];
+        _ = Emitter::default()
+            .add_instructions(&git2)?
+            .emit_to(&mut stdout_buf)?;
+        let output = String::from_utf8_lossy(&stdout_buf);
+        let line = output
+            .lines()
+            .find(|l| l.starts_with("cargo:rustc-env=VERGEN_GIT_COMMIT_TIMESTAMP_UNIX="))
+            .expect("unix commit timestamp emitted");
+        let value = line.trim_start_matches("cargo:rustc-env=VERGEN_GIT_COMMIT_TIMESTAMP_UNIX=");
+        assert!(value.parse::<i64>().is_ok(), "value: {value}");
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn commit_timestamp_unix_idempotent() -> Result<()> {
+        let git2 = Git2::builder().commit_timestamp_unix(true).build();
+        let emitter = Emitter::default()
+            .idempotent()
+            .add_instructions(&git2)?
+            .test_emit();
+        assert_eq!(1, emitter.cargo_rustc_env_map().len());
+        assert_eq!(1, count_idempotent(emitter.cargo_rustc_env_map()));
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn commit_timestamp_unix_override_works() {
+        temp_env::with_var("VERGEN_GIT_COMMIT_TIMESTAMP_UNIX", Some("12345"), || {
+            let result = || -> Result<()> {
+                let git2 = Git2::builder().commit_timestamp_unix(true).build();
+                let mut stdout_buf = vec![];
+                _ = Emitter::default()
+                    .add_instructions(&git2)?
+                    .emit_to(&mut stdout_buf)?;
+                let output = String::from_utf8_lossy(&stdout_buf);
+                assert!(
+                    output.contains("cargo:rustc-env=VERGEN_GIT_COMMIT_TIMESTAMP_UNIX=12345"),
+                    "{output}"
+                );
+                Ok(())
+            }();
+            assert!(result.is_ok());
+        });
     }
 }

--- a/vergen-gitcl/src/gitcl/mod.rs
+++ b/vergen-gitcl/src/gitcl/mod.rs
@@ -28,8 +28,8 @@ use vergen_lib::{
     Dirty, Sha, VergenKey, add_default_map_entry, add_map_entry,
     constants::{
         GIT_BRANCH_NAME, GIT_COMMIT_AUTHOR_EMAIL, GIT_COMMIT_AUTHOR_NAME, GIT_COMMIT_COUNT,
-        GIT_COMMIT_DATE_NAME, GIT_COMMIT_MESSAGE, GIT_COMMIT_TIMESTAMP_NAME, GIT_DESCRIBE_NAME,
-        GIT_DIRTY_NAME, GIT_SHA_NAME,
+        GIT_COMMIT_DATE_NAME, GIT_COMMIT_MESSAGE, GIT_COMMIT_TIMESTAMP_NAME,
+        GIT_COMMIT_TIMESTAMP_UNIX_NAME, GIT_DESCRIBE_NAME, GIT_DIRTY_NAME, GIT_SHA_NAME,
     },
 };
 
@@ -297,6 +297,15 @@ pub struct Gitcl {
     ///
     #[builder(default = all)]
     commit_timestamp: bool,
+    /// Emit the commit timestamp of the latest commit as Unix seconds
+    ///
+    /// ```text
+    /// cargo:rustc-env=VERGEN_GIT_COMMIT_TIMESTAMP_UNIX=<SECONDS>
+    /// ```
+    ///
+    /// This is opt-in and is not enabled by [`Gitcl::all_git`].
+    #[builder(default = false)]
+    commit_timestamp_unix: bool,
     /// Emit the describe output
     ///
     /// ```text
@@ -392,6 +401,7 @@ impl Gitcl {
             || self.commit_date
             || self.commit_message
             || self.commit_timestamp
+            || self.commit_timestamp_unix
             || self.describe.is_some()
             || self.sha.is_some()
             || self.dirty.is_some()
@@ -776,6 +786,7 @@ impl Gitcl {
         Ok(())
     }
 
+    #[allow(clippy::too_many_lines)]
     fn add_git_timestamp_entries(
         &self,
         cmd: &str,
@@ -804,6 +815,17 @@ impl Gitcl {
                 cargo_warning,
             );
             timestamp_override = true;
+        }
+
+        let mut timestamp_unix_override = false;
+        if let Ok(_value) = env::var(GIT_COMMIT_TIMESTAMP_UNIX_NAME) {
+            add_default_map_entry(
+                idempotent,
+                VergenKey::GitCommitTimestampUnix,
+                cargo_rustc_env,
+                cargo_warning,
+            );
+            timestamp_unix_override = true;
         }
 
         let output = Self::run_cmd(cmd, path)?;
@@ -839,6 +861,15 @@ impl Gitcl {
                         cargo_warning,
                     );
                 }
+
+                if self.commit_timestamp_unix && !timestamp_unix_override {
+                    add_default_map_entry(
+                        idempotent,
+                        VergenKey::GitCommitTimestampUnix,
+                        cargo_rustc_env,
+                        cargo_warning,
+                    );
+                }
             } else {
                 if self.commit_date && !date_override {
                     let format = format_description::parse("[year]-[month]-[day]")?;
@@ -853,6 +884,14 @@ impl Gitcl {
                     add_map_entry(
                         VergenKey::GitCommitTimestamp,
                         ts.format(&Iso8601::DEFAULT)?,
+                        cargo_rustc_env,
+                    );
+                }
+
+                if self.commit_timestamp_unix && !timestamp_unix_override {
+                    add_map_entry(
+                        VergenKey::GitCommitTimestampUnix,
+                        ts.unix_timestamp().to_string(),
                         cargo_rustc_env,
                     );
                 }
@@ -871,6 +910,15 @@ impl Gitcl {
                 add_default_map_entry(
                     idempotent,
                     VergenKey::GitCommitTimestamp,
+                    cargo_rustc_env,
+                    cargo_warning,
+                );
+            }
+
+            if self.commit_timestamp_unix && !timestamp_unix_override {
+                add_default_map_entry(
+                    idempotent,
+                    VergenKey::GitCommitTimestampUnix,
                     cargo_rustc_env,
                     cargo_warning,
                 );
@@ -1029,6 +1077,7 @@ impl AddEntries for Gitcl {
         Ok(())
     }
 
+    #[allow(clippy::too_many_lines)]
     fn add_default_entries(
         &self,
         config: &DefaultConfig,
@@ -1103,6 +1152,14 @@ impl AddEntries for Gitcl {
                 add_default_map_entry(
                     *config.idempotent(),
                     VergenKey::GitCommitTimestamp,
+                    cargo_rustc_env_map,
+                    cargo_warning,
+                );
+            }
+            if self.commit_timestamp_unix {
+                add_default_map_entry(
+                    *config.idempotent(),
+                    VergenKey::GitCommitTimestampUnix,
                     cargo_rustc_env_map,
                     cargo_warning,
                 );
@@ -1669,5 +1726,57 @@ mod test {
             "{output}"
         );
         Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn commit_timestamp_unix_works() -> Result<()> {
+        let gitcl = Gitcl::builder().commit_timestamp_unix(true).build();
+        let mut stdout_buf = vec![];
+        _ = Emitter::default()
+            .add_instructions(&gitcl)?
+            .emit_to(&mut stdout_buf)?;
+        let output = String::from_utf8_lossy(&stdout_buf);
+        let line = output
+            .lines()
+            .find(|l| l.starts_with("cargo:rustc-env=VERGEN_GIT_COMMIT_TIMESTAMP_UNIX="))
+            .expect("unix commit timestamp emitted");
+        let value = line.trim_start_matches("cargo:rustc-env=VERGEN_GIT_COMMIT_TIMESTAMP_UNIX=");
+        assert!(value.parse::<i64>().is_ok(), "value: {value}");
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn commit_timestamp_unix_idempotent() -> Result<()> {
+        let gitcl = Gitcl::builder().commit_timestamp_unix(true).build();
+        let emitter = Emitter::default()
+            .idempotent()
+            .add_instructions(&gitcl)?
+            .test_emit();
+        assert_eq!(1, emitter.cargo_rustc_env_map().len());
+        assert_eq!(1, count_idempotent(emitter.cargo_rustc_env_map()));
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn commit_timestamp_unix_override_works() {
+        temp_env::with_var("VERGEN_GIT_COMMIT_TIMESTAMP_UNIX", Some("12345"), || {
+            let result = || -> Result<()> {
+                let gitcl = Gitcl::builder().commit_timestamp_unix(true).build();
+                let mut stdout_buf = vec![];
+                _ = Emitter::default()
+                    .add_instructions(&gitcl)?
+                    .emit_to(&mut stdout_buf)?;
+                let output = String::from_utf8_lossy(&stdout_buf);
+                assert!(
+                    output.contains("cargo:rustc-env=VERGEN_GIT_COMMIT_TIMESTAMP_UNIX=12345"),
+                    "{output}"
+                );
+                Ok(())
+            }();
+            assert!(result.is_ok());
+        });
     }
 }

--- a/vergen-gix/src/gix/mod.rs
+++ b/vergen-gix/src/gix/mod.rs
@@ -28,8 +28,8 @@ use vergen_lib::{
     Dirty, Sha, VergenKey, add_default_map_entry, add_map_entry,
     constants::{
         GIT_BRANCH_NAME, GIT_COMMIT_AUTHOR_EMAIL, GIT_COMMIT_AUTHOR_NAME, GIT_COMMIT_COUNT,
-        GIT_COMMIT_DATE_NAME, GIT_COMMIT_MESSAGE, GIT_COMMIT_TIMESTAMP_NAME, GIT_DESCRIBE_NAME,
-        GIT_DIRTY_NAME, GIT_SHA_NAME,
+        GIT_COMMIT_DATE_NAME, GIT_COMMIT_MESSAGE, GIT_COMMIT_TIMESTAMP_NAME,
+        GIT_COMMIT_TIMESTAMP_UNIX_NAME, GIT_DESCRIBE_NAME, GIT_DIRTY_NAME, GIT_SHA_NAME,
     },
 };
 #[cfg(feature = "allow_remote")]
@@ -174,6 +174,15 @@ pub struct Gix {
     ///
     #[builder(default = all)]
     commit_timestamp: bool,
+    /// Emit the commit timestamp of the latest commit as Unix seconds
+    ///
+    /// ```text
+    /// cargo:rustc-env=VERGEN_GIT_COMMIT_TIMESTAMP_UNIX=<SECONDS>
+    /// ```
+    ///
+    /// This is opt-in and is not enabled by [`Gix::all_git`].
+    #[builder(default = false)]
+    commit_timestamp_unix: bool,
     /// Emit the describe output
     ///
     /// ```text
@@ -267,6 +276,7 @@ impl Gix {
             || self.commit_date
             || self.commit_message
             || self.commit_timestamp
+            || self.commit_timestamp_unix
             || self.describe.is_some()
             || self.sha.is_some()
             || self.dirty.is_some()
@@ -653,7 +663,42 @@ impl Gix {
         } else {
             self.add_git_timestamp_entry(idempotent, &ts, cargo_rustc_env, cargo_warning)?;
         }
+        if let Ok(_value) = env::var(GIT_COMMIT_TIMESTAMP_UNIX_NAME) {
+            add_default_map_entry(
+                idempotent,
+                VergenKey::GitCommitTimestampUnix,
+                cargo_rustc_env,
+                cargo_warning,
+            );
+        } else {
+            self.add_git_timestamp_unix_entry(idempotent, &ts, cargo_rustc_env, cargo_warning);
+        }
         Ok(())
+    }
+
+    fn add_git_timestamp_unix_entry(
+        &self,
+        idempotent: bool,
+        ts: &OffsetDateTime,
+        cargo_rustc_env: &mut CargoRustcEnvMap,
+        cargo_warning: &mut CargoWarning,
+    ) {
+        if self.commit_timestamp_unix {
+            if idempotent {
+                add_default_map_entry(
+                    idempotent,
+                    VergenKey::GitCommitTimestampUnix,
+                    cargo_rustc_env,
+                    cargo_warning,
+                );
+            } else {
+                add_map_entry(
+                    VergenKey::GitCommitTimestampUnix,
+                    ts.unix_timestamp().to_string(),
+                    cargo_rustc_env,
+                );
+            }
+        }
     }
 
     #[cfg_attr(coverage_nightly, coverage(off))]
@@ -756,6 +801,7 @@ impl AddEntries for Gix {
         )
     }
 
+    #[allow(clippy::too_many_lines)]
     fn add_default_entries(
         &self,
         config: &DefaultConfig,
@@ -829,6 +875,14 @@ impl AddEntries for Gix {
                 add_default_map_entry(
                     *config.idempotent(),
                     VergenKey::GitCommitTimestamp,
+                    cargo_rustc_env_map,
+                    cargo_warning,
+                );
+            }
+            if self.commit_timestamp_unix {
+                add_default_map_entry(
+                    *config.idempotent(),
+                    VergenKey::GitCommitTimestampUnix,
                     cargo_rustc_env_map,
                     cargo_warning,
                 );
@@ -1386,5 +1440,57 @@ mod test {
             "{output}"
         );
         Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn commit_timestamp_unix_works() -> Result<()> {
+        let gix = Gix::builder().commit_timestamp_unix(true).build();
+        let mut stdout_buf = vec![];
+        _ = Emitter::default()
+            .add_instructions(&gix)?
+            .emit_to(&mut stdout_buf)?;
+        let output = String::from_utf8_lossy(&stdout_buf);
+        let line = output
+            .lines()
+            .find(|l| l.starts_with("cargo:rustc-env=VERGEN_GIT_COMMIT_TIMESTAMP_UNIX="))
+            .expect("unix commit timestamp emitted");
+        let value = line.trim_start_matches("cargo:rustc-env=VERGEN_GIT_COMMIT_TIMESTAMP_UNIX=");
+        assert!(value.parse::<i64>().is_ok(), "value: {value}");
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn commit_timestamp_unix_idempotent() -> Result<()> {
+        let gix = Gix::builder().commit_timestamp_unix(true).build();
+        let emitter = Emitter::default()
+            .idempotent()
+            .add_instructions(&gix)?
+            .test_emit();
+        assert_eq!(1, emitter.cargo_rustc_env_map().len());
+        assert_eq!(1, count_idempotent(emitter.cargo_rustc_env_map()));
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn commit_timestamp_unix_override_works() {
+        temp_env::with_var("VERGEN_GIT_COMMIT_TIMESTAMP_UNIX", Some("12345"), || {
+            let result = || -> Result<()> {
+                let gix = Gix::builder().commit_timestamp_unix(true).build();
+                let mut stdout_buf = vec![];
+                _ = Emitter::default()
+                    .add_instructions(&gix)?
+                    .emit_to(&mut stdout_buf)?;
+                let output = String::from_utf8_lossy(&stdout_buf);
+                assert!(
+                    output.contains("cargo:rustc-env=VERGEN_GIT_COMMIT_TIMESTAMP_UNIX=12345"),
+                    "{output}"
+                );
+                Ok(())
+            }();
+            assert!(result.is_ok());
+        });
     }
 }

--- a/vergen-lib/src/constants.rs
+++ b/vergen-lib/src/constants.rs
@@ -32,6 +32,9 @@ pub mod features {
     /// The timestamp of the current build
     #[cfg(feature = "build")]
     pub const BUILD_TIMESTAMP_NAME: &str = "VERGEN_BUILD_TIMESTAMP";
+    /// The timestamp of the current build as Unix seconds since the epoch
+    #[cfg(feature = "build")]
+    pub const BUILD_TIMESTAMP_UNIX_NAME: &str = "VERGEN_BUILD_TIMESTAMP_UNIX";
     /// The date of the current build
     #[cfg(feature = "build")]
     pub const BUILD_DATE_NAME: &str = "VERGEN_BUILD_DATE";
@@ -57,6 +60,9 @@ pub mod features {
     /// The most recent commit timestamp
     #[cfg(feature = "git")]
     pub const GIT_COMMIT_TIMESTAMP_NAME: &str = "VERGEN_GIT_COMMIT_TIMESTAMP";
+    /// The most recent commit timestamp as Unix seconds since the epoch
+    #[cfg(feature = "git")]
+    pub const GIT_COMMIT_TIMESTAMP_UNIX_NAME: &str = "VERGEN_GIT_COMMIT_TIMESTAMP_UNIX";
     /// The output of git describe
     #[cfg(feature = "git")]
     pub const GIT_DESCRIBE_NAME: &str = "VERGEN_GIT_DESCRIBE";
@@ -160,6 +166,7 @@ mod test {
     fn build_constants_dont_change() {
         // Build Constants
         assert_eq!(BUILD_TIMESTAMP_NAME, "VERGEN_BUILD_TIMESTAMP");
+        assert_eq!(BUILD_TIMESTAMP_UNIX_NAME, "VERGEN_BUILD_TIMESTAMP_UNIX");
         assert_eq!(BUILD_DATE_NAME, "VERGEN_BUILD_DATE");
     }
 
@@ -182,6 +189,10 @@ mod test {
         assert_eq!(GIT_COMMIT_MESSAGE, "VERGEN_GIT_COMMIT_MESSAGE");
         assert_eq!(GIT_COMMIT_DATE_NAME, "VERGEN_GIT_COMMIT_DATE");
         assert_eq!(GIT_COMMIT_TIMESTAMP_NAME, "VERGEN_GIT_COMMIT_TIMESTAMP");
+        assert_eq!(
+            GIT_COMMIT_TIMESTAMP_UNIX_NAME,
+            "VERGEN_GIT_COMMIT_TIMESTAMP_UNIX"
+        );
         assert_eq!(GIT_DESCRIBE_NAME, "VERGEN_GIT_DESCRIBE");
         assert_eq!(GIT_SHA_NAME, "VERGEN_GIT_SHA");
         assert_eq!(GIT_DIRTY_NAME, "VERGEN_GIT_DIRTY");

--- a/vergen-lib/src/keys.rs
+++ b/vergen-lib/src/keys.rs
@@ -16,7 +16,7 @@
 ))]
 pub(crate) mod vergen_key {
     #[cfg(feature = "build")]
-    use crate::constants::{BUILD_DATE_NAME, BUILD_TIMESTAMP_NAME};
+    use crate::constants::{BUILD_DATE_NAME, BUILD_TIMESTAMP_NAME, BUILD_TIMESTAMP_UNIX_NAME};
     #[cfg(feature = "cargo")]
     use crate::constants::{
         CARGO_DEBUG, CARGO_DEPENDENCIES, CARGO_FEATURES, CARGO_OPT_LEVEL, CARGO_TARGET_TRIPLE,
@@ -24,8 +24,8 @@ pub(crate) mod vergen_key {
     #[cfg(feature = "git")]
     use crate::constants::{
         GIT_BRANCH_NAME, GIT_COMMIT_AUTHOR_EMAIL, GIT_COMMIT_AUTHOR_NAME, GIT_COMMIT_COUNT,
-        GIT_COMMIT_DATE_NAME, GIT_COMMIT_MESSAGE, GIT_COMMIT_TIMESTAMP_NAME, GIT_DESCRIBE_NAME,
-        GIT_DIRTY_NAME, GIT_SHA_NAME,
+        GIT_COMMIT_DATE_NAME, GIT_COMMIT_MESSAGE, GIT_COMMIT_TIMESTAMP_NAME,
+        GIT_COMMIT_TIMESTAMP_UNIX_NAME, GIT_DESCRIBE_NAME, GIT_DIRTY_NAME, GIT_SHA_NAME,
     };
     #[cfg(feature = "rustc")]
     use crate::constants::{
@@ -47,6 +47,9 @@ pub(crate) mod vergen_key {
         /// The build timestamp. (`VERGEN_BUILD_TIMESTAMP`)
         #[cfg(feature = "build")]
         BuildTimestamp,
+        /// The build timestamp as Unix seconds. (`VERGEN_BUILD_TIMESTAMP_UNIX`)
+        #[cfg(feature = "build")]
+        BuildTimestampUnix,
         /// The cargo debug flag (`VERGEN_CARGO_DEBUG`)
         #[cfg(feature = "cargo")]
         CargoDebug,
@@ -83,6 +86,9 @@ pub(crate) mod vergen_key {
         /// The commit timestamp. (`VERGEN_GIT_COMMIT_TIMESTAMP`)
         #[cfg(feature = "git")]
         GitCommitTimestamp,
+        /// The commit timestamp as Unix seconds. (`VERGEN_GIT_COMMIT_TIMESTAMP_UNIX`)
+        #[cfg(feature = "git")]
+        GitCommitTimestampUnix,
         /// The semver version from the last git tag. (`VERGEN_GIT_SEMVER`)
         #[cfg(feature = "git")]
         GitDescribe,
@@ -148,6 +154,8 @@ pub(crate) mod vergen_key {
                 VergenKey::BuildDate => BUILD_DATE_NAME,
                 #[cfg(feature = "build")]
                 VergenKey::BuildTimestamp => BUILD_TIMESTAMP_NAME,
+                #[cfg(feature = "build")]
+                VergenKey::BuildTimestampUnix => BUILD_TIMESTAMP_UNIX_NAME,
                 #[cfg(feature = "cargo")]
                 VergenKey::CargoDebug => CARGO_DEBUG,
                 #[cfg(feature = "cargo")]
@@ -172,6 +180,8 @@ pub(crate) mod vergen_key {
                 VergenKey::GitCommitMessage => GIT_COMMIT_MESSAGE,
                 #[cfg(feature = "git")]
                 VergenKey::GitCommitTimestamp => GIT_COMMIT_TIMESTAMP_NAME,
+                #[cfg(feature = "git")]
+                VergenKey::GitCommitTimestampUnix => GIT_COMMIT_TIMESTAMP_UNIX_NAME,
                 #[cfg(feature = "git")]
                 VergenKey::GitDescribe => GIT_DESCRIBE_NAME,
                 #[cfg(feature = "git")]

--- a/vergen/src/feature/build.rs
+++ b/vergen/src/feature/build.rs
@@ -19,7 +19,7 @@ use time::{
 use vergen_lib::{
     AddEntries, CargoRerunIfChanged, CargoRustcEnvMap, CargoWarning, DefaultConfig, VergenKey,
     add_default_map_entry, add_map_entry,
-    constants::{BUILD_DATE_NAME, BUILD_TIMESTAMP_NAME},
+    constants::{BUILD_DATE_NAME, BUILD_TIMESTAMP_NAME, BUILD_TIMESTAMP_UNIX_NAME},
 };
 
 /// The `VERGEN_BUILD_*` configuration features
@@ -157,6 +157,12 @@ pub struct Build {
     /// Enable the `VERGEN_BUILD_TIMESTAMP` date output
     #[builder(default = all)]
     build_timestamp: bool,
+    /// Enable the `VERGEN_BUILD_TIMESTAMP_UNIX` output (the build timestamp as
+    /// Unix seconds since the epoch).
+    ///
+    /// This is opt-in and is not enabled by [`Build::all_build`].
+    #[builder(default = false)]
+    build_timestamp_unix: bool,
     /// Enable local offset date/timestamp output
     #[builder(default = false)]
     use_local: bool,
@@ -185,7 +191,7 @@ impl Build {
     }
 
     fn any(self) -> bool {
-        self.build_date || self.build_timestamp
+        self.build_date || self.build_timestamp || self.build_timestamp_unix
     }
 
     fn add_timestamp_entries(
@@ -211,6 +217,7 @@ impl Build {
 
         self.add_date_entry(idempotent, sde, &ts, cargo_rustc_env, cargo_warning)?;
         self.add_timestamp_entry(idempotent, sde, &ts, cargo_rustc_env, cargo_warning)?;
+        self.add_timestamp_unix_entry(idempotent, sde, &ts, cargo_rustc_env, cargo_warning);
         Ok(())
     }
 
@@ -268,6 +275,34 @@ impl Build {
         }
         Ok(())
     }
+
+    fn add_timestamp_unix_entry(
+        self,
+        idempotent: bool,
+        source_date_epoch: bool,
+        ts: &OffsetDateTime,
+        cargo_rustc_env: &mut CargoRustcEnvMap,
+        cargo_warning: &mut CargoWarning,
+    ) {
+        if self.build_timestamp_unix {
+            if let Ok(value) = env::var(BUILD_TIMESTAMP_UNIX_NAME) {
+                add_map_entry(VergenKey::BuildTimestampUnix, value, cargo_rustc_env);
+            } else if idempotent && !source_date_epoch {
+                add_default_map_entry(
+                    idempotent,
+                    VergenKey::BuildTimestampUnix,
+                    cargo_rustc_env,
+                    cargo_warning,
+                );
+            } else {
+                add_map_entry(
+                    VergenKey::BuildTimestampUnix,
+                    ts.unix_timestamp().to_string(),
+                    cargo_rustc_env,
+                );
+            }
+        }
+    }
 }
 
 impl AddEntries for Build {
@@ -308,6 +343,14 @@ impl AddEntries for Build {
                 add_default_map_entry(
                     *config.idempotent(),
                     VergenKey::BuildTimestamp,
+                    cargo_rustc_env_map,
+                    cargo_warning,
+                );
+            }
+            if self.build_timestamp_unix {
+                add_default_map_entry(
+                    *config.idempotent(),
+                    VergenKey::BuildTimestampUnix,
                     cargo_rustc_env_map,
                     cargo_warning,
                 );
@@ -481,6 +524,61 @@ mod test {
                         );
                     }
                 }
+                Ok(())
+            }();
+            assert!(result.is_ok());
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn build_timestamp_unix_works() {
+        temp_env::with_var("SOURCE_DATE_EPOCH", Some("1671809360"), || {
+            let result = || -> Result<()> {
+                let mut stdout_buf = vec![];
+                let build = Build::builder().build_timestamp_unix(true).build();
+                _ = Emitter::new()
+                    .add_instructions(&build)?
+                    .emit_to(&mut stdout_buf)?;
+                let output = String::from_utf8_lossy(&stdout_buf);
+                assert!(
+                    output.contains("cargo:rustc-env=VERGEN_BUILD_TIMESTAMP_UNIX=1671809360"),
+                    "{output}"
+                );
+                Ok(())
+            }();
+            assert!(result.is_ok());
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn build_timestamp_unix_idempotent() -> Result<()> {
+        let build = Build::builder().build_timestamp_unix(true).build();
+        let emitter = Emitter::default()
+            .idempotent()
+            .add_instructions(&build)?
+            .test_emit();
+        assert_eq!(1, emitter.cargo_rustc_env_map().len());
+        assert_eq!(1, count_idempotent(emitter.cargo_rustc_env_map()));
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn build_timestamp_unix_override_works() {
+        temp_env::with_var("VERGEN_BUILD_TIMESTAMP_UNIX", Some("12345"), || {
+            let result = || -> Result<()> {
+                let mut stdout_buf = vec![];
+                let build = Build::builder().build_timestamp_unix(true).build();
+                _ = Emitter::default()
+                    .add_instructions(&build)?
+                    .emit_to(&mut stdout_buf)?;
+                let output = String::from_utf8_lossy(&stdout_buf);
+                assert!(
+                    output.contains("cargo:rustc-env=VERGEN_BUILD_TIMESTAMP_UNIX=12345"),
+                    "{output}"
+                );
                 Ok(())
             }();
             assert!(result.is_ok());


### PR DESCRIPTION
Adds opt-in Unix-seconds timestamp output, as requested in #444.

## What
- **`VERGEN_BUILD_TIMESTAMP_UNIX`** — new `build_timestamp_unix` option on the `build` feature.
- **`VERGEN_GIT_COMMIT_TIMESTAMP_UNIX`** — new `commit_timestamp_unix` option on all three git backends (git2, gix, gitcl).

Both emit the timestamp as bare Unix seconds since the epoch, alongside the existing RFC3339 `*_TIMESTAMP` values.

## Behavior
- **Opt-in**: `default = false`, and *not* included in `all_build()` / `all_git()`, so existing output and counts are unchanged.
- Honors the env-var override (e.g. `VERGEN_BUILD_TIMESTAMP_UNIX=...`) and the `idempotent` flag (emits the idempotent sentinel) just like the RFC3339 timestamps.
- The build timestamp still honors `SOURCE_DATE_EPOCH`; the git commit timestamp is unaffected by it (consistent with #452).
- New `BuildTimestampUnix` / `GitCommitTimestampUnix` `VergenKey` variants + name constants.

Each backend has integer-emit, idempotent, and override tests. Verified: `cargo test` + `cargo clippy` + `fmt`.

### Note
Stacked on #498 (it shares the git-backend timestamp code, and the git commit unix value must match #452's SOURCE_DATE_EPOCH behavior). Retarget to `master` after #498 merges.

Closes #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)