### PR TITLE
(ci): add cargo-semver-checks job (#478)

### DIFF
--- a/.github/workflows/vergen.yml
+++ b/.github/workflows/vergen.yml
@@ -201,3 +201,30 @@ jobs:
     name: vergen-pretty
     uses: ./.github/workflows/vergen_pretty.yml
     secrets: inherit
+
+  semver-checks:
+    name: 🔍 Semver Checks 🔍
+    # Informational during the 10.0 beta: there is no stable 10.0 baseline on
+    # crates.io yet, so the intentional major-version breaks are expected to be
+    # reported. Drop `continue-on-error` and add this as a required status check
+    # once 10.0.0 ships. See issue #478.
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    steps:
+      - name: ✅ Checkout ✅
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: 💾 Install (cargo-binstall) 💾
+        uses: cargo-bins/cargo-binstall@aaa84a43aec4955a42c5ffc65d258961e39f276e # v1.19.1
+      - name: 💾 Install (cargo-semver-checks) 💾
+        env:
+          BINSTALL_MAXIMUM_RESOLUTION_TIMEOUT: "20"
+        run: cargo binstall --no-confirm --no-symlinks cargo-semver-checks
+      - name: 🔍 Semver Checks 🔍
+        run: >-
+          cargo semver-checks
+          --package vergen-lib
+          --package vergen
+          --package vergen-git2
+          --package vergen-gitcl
+          --package vergen-gix
+          --package vergen-pretty


### PR DESCRIPTION
Adds a `cargo-semver-checks` CI job to guard against the #478 class of breakage — a crate exposing another crate's types in its public API without a matching major-version bump (what caused vergen-gitcl 9.1.0 to break when vergen-lib jumped majors).

## What
A new `semver-checks` job in `vergen.yml` that installs `cargo-semver-checks` (via the repo's pinned `cargo-binstall`) and runs it against the six published crates (`vergen-lib`, `vergen`, `vergen-git2`, `vergen-gitcl`, `vergen-gix`, `vergen-pretty`).

## Informational during the beta
The job is `continue-on-error: true` for now. There's no stable 10.0 baseline on crates.io yet, so the intentional v10 major breaks would otherwise be reported as failures. The infrastructure is in place; once **10.0.0** ships:
1. drop `continue-on-error`, and
2. add `🔍 Semver Checks 🔍` as a required status check in the branch ruleset.

Actions are SHA-pinned (`actions/checkout` v6.0.3, `cargo-bins/cargo-binstall` v1.19.1) per the repo convention, and the binstall step uses `BINSTALL_MAXIMUM_RESOLUTION_TIMEOUT` like the shared workflows.

Independent of #498/#499 (only touches `vergen.yml`).

Closes #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)