### PR TITLE
(chore): release 10.0.0

### DIFF
--- a/test_util/Cargo.toml
+++ b/test_util/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.95.0"
 name = "test_util"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "10.0.0-beta.9"
+version = "10.0.0"
 
 [package.metadata.cargo-matrix]
 [[package.metadata.cargo-matrix.channel]]

--- a/vergen-git2/Cargo.toml
+++ b/vergen-git2/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.95.0"
 name = "vergen-git2"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "10.0.0-beta.9"
+version = "10.0.0"
 
 [package.metadata.cargo-matrix]
 [[package.metadata.cargo-matrix.channel]]
@@ -57,8 +57,8 @@ anyhow = { workspace = true }
 bon = { workspace = true }
 git2-rs = { version = "0.21.0", package = "git2", default-features = false }
 time = { workspace = true }
-vergen = { version = "10.0.0-beta.9", path = "../vergen", default-features = false }
-vergen-lib = { version = "10.0.0-beta.9", path = "../vergen-lib", features = [
+vergen = { version = "10.0.0", path = "../vergen", default-features = false }
+vergen-lib = { version = "10.0.0", path = "../vergen-lib", features = [
     "git",
 ] }
 

--- a/vergen-gitcl/Cargo.toml
+++ b/vergen-gitcl/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.95.0"
 name = "vergen-gitcl"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "10.0.0-beta.9"
+version = "10.0.0"
 
 [package.metadata.cargo-matrix]
 [[package.metadata.cargo-matrix.channel]]
@@ -54,8 +54,8 @@ vcs_info = ["vergen-lib/vcs_info"]
 anyhow = { workspace = true }
 bon = { workspace = true }
 time = { workspace = true }
-vergen = { version = "10.0.0-beta.9", path = "../vergen", default-features = false }
-vergen-lib = { version = "10.0.0-beta.9", path = "../vergen-lib", features = ["git"] }
+vergen = { version = "10.0.0", path = "../vergen", default-features = false }
+vergen-lib = { version = "10.0.0", path = "../vergen-lib", features = ["git"] }
 
 [build-dependencies]
 rustversion = { workspace = true }

--- a/vergen-gix/Cargo.toml
+++ b/vergen-gix/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.95.0"
 name = "vergen-gix"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "10.0.0-beta.9"
+version = "10.0.0"
 
 [package.metadata.cargo-matrix]
 [[package.metadata.cargo-matrix.channel]]
@@ -73,8 +73,8 @@ gix = { workspace = true, features = [
     "sha1",
 ] }
 time = { workspace = true }
-vergen = { version = "10.0.0-beta.9", path = "../vergen", default-features = false }
-vergen-lib = { version = "10.0.0-beta.9", path = "../vergen-lib", features = [
+vergen = { version = "10.0.0", path = "../vergen", default-features = false }
+vergen-lib = { version = "10.0.0", path = "../vergen-lib", features = [
     "git",
 ] }
 

--- a/vergen-lib/Cargo.toml
+++ b/vergen-lib/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.95.0"
 name = "vergen-lib"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "10.0.0-beta.9"
+version = "10.0.0"
 
 [package.metadata.cargo-matrix]
 [[package.metadata.cargo-matrix.channel]]

--- a/vergen-pretty/Cargo.toml
+++ b/vergen-pretty/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.95.0"
 name = "vergen-pretty"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "10.0.0-beta.9"
+version = "10.0.0"
 
 [package.metadata.cargo-matrix]
 [[package.metadata.cargo-matrix.channel]]
@@ -58,7 +58,7 @@ tracing = { version = "0.1.44", features = [
 [build-dependencies]
 anyhow = { workspace = true }
 rustversion = { workspace = true }
-vergen-gix = { version = "10.0.0-beta.9", path = "../vergen-gix", features = [
+vergen-gix = { version = "10.0.0", path = "../vergen-gix", features = [
     "build",
     "cargo",
     "rustc",

--- a/vergen/Cargo.toml
+++ b/vergen/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.95.0"
 name = "vergen"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "10.0.0-beta.9"
+version = "10.0.0"
 
 [package.metadata.cargo-matrix]
 [[package.metadata.cargo-matrix.channel]]
@@ -41,7 +41,7 @@ regex = { workspace = true, optional = true }
 rustc_version = { version = "0.4.1", optional = true }
 sysinfo = { version = "0.39.3", optional = true }
 time = { workspace = true, optional = true }
-vergen-lib = { version = "10.0.0-beta.9", path = "../vergen-lib" }
+vergen-lib = { version = "10.0.0", path = "../vergen-lib" }
 
 [build-dependencies]
 rustversion = { workspace = true }


### PR DESCRIPTION
## Summary

Bumps all workspace crates from `10.0.0-beta.9` to the final `10.0.0` release version, completing the release-10 preparation work (closes #493).

Updated crates:
- `vergen`
- `vergen-lib`
- `vergen-git2`
- `vergen-gitcl`
- `vergen-gix`
- `vergen-pretty`
- `test_util`

Internal path dependencies between the crates were updated to match.

## Context

Earlier release-prep work on this branch landed via #495 and #496 (depsup, MSRV 1.95.0, CI pinning + parallelization), plus the feature/fix PRs #498, #499, #500. This is the final version bump to ship 10.0.0.

Closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)