### PR TITLE
Fix time crate parse deprecation warnings

### DIFF
--- a/vergen-git2/src/git2/mod.rs
+++ b/vergen-git2/src/git2/mod.rs
@@ -832,7 +832,7 @@ impl Git2 {
                     cargo_warning,
                 );
             } else {
-                let format = format_description::parse("[year]-[month]-[day]")?;
+                let format = format_description::parse_borrowed::<1>("[year]-[month]-[day]")?;
                 add_map_entry(
                     VergenKey::GitCommitDate,
                     ts.format(&format)?,

--- a/vergen-gitcl/src/gitcl/mod.rs
+++ b/vergen-gitcl/src/gitcl/mod.rs
@@ -872,7 +872,7 @@ impl Gitcl {
                 }
             } else {
                 if self.commit_date && !date_override {
-                    let format = format_description::parse("[year]-[month]-[day]")?;
+                    let format = format_description::parse_borrowed::<1>("[year]-[month]-[day]")?;
                     add_map_entry(
                         VergenKey::GitCommitDate,
                         ts.format(&format)?,

--- a/vergen-gix/src/gix/mod.rs
+++ b/vergen-gix/src/gix/mod.rs
@@ -730,7 +730,7 @@ impl Gix {
                     cargo_warning,
                 );
             } else {
-                let format = format_description::parse("[year]-[month]-[day]")?;
+                let format = format_description::parse_borrowed::<1>("[year]-[month]-[day]")?;
                 add_map_entry(
                     VergenKey::GitCommitDate,
                     ts.format(&format)?,

--- a/vergen/src/feature/build.rs
+++ b/vergen/src/feature/build.rs
@@ -240,7 +240,7 @@ impl Build {
                     cargo_warning,
                 );
             } else {
-                let format = format_description::parse("[year]-[month]-[day]")?;
+                let format = format_description::parse_borrowed::<1>("[year]-[month]-[day]")?;
                 add_map_entry(VergenKey::BuildDate, ts.format(&format)?, cargo_rustc_env);
             }
         }


### PR DESCRIPTION
## Summary

Replaces the deprecated `format_description::parse(...)` calls with the non-deprecated `format_description::parse_borrowed::<1>(...)` across the build- and git-date formatting paths.

## Changes

- `vergen/src/feature/build.rs` — build date format
- `vergen-git2/src/git2/mod.rs` — git commit date format
- `vergen-gitcl/src/gitcl/mod.rs` — git commit date format
- `vergen-gix/src/gix/mod.rs` — git commit date format

## Test plan

- [ ] `scripts/run_all.fish` (fmt, clippy, build, test, coverage, docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)