### PR TITLE
v10.0.1 enhancements: VERGEN_DEFAULT_ON_ERROR fallback, dependency updates, and audit refresh

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,2 +1,2 @@
 [advisories]
-ignore = ["RUSTSEC-2025-0055","RUSTSEC-2025-0141"]
+ignore = ["RUSTSEC-2026-0173"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,20 +13,20 @@ members = [
 
 [workspace.dependencies]
 anyhow = "1.0.102"
-bon = "3.9.1"
-gix = { version = "0.84.0", default-features = false, features = [
+bon = "3.9.3"
+gix = { version = "0.85.0", default-features = false, features = [
     "revision",
     "worktree-mutation",
     "blocking-network-client",
     "sha1",
 ] }
 rand = { version = "0.10.1" }
-regex = { version = "1.12.3" }
+regex = { version = "1.12.4" }
 rustversion = "1.0.22"
 serde_json = "1.0.150"
 serial_test = "3.5.0"
 temp-env = "0.3.6"
-time = { version = "0.3.47", features = [
+time = { version = "0.3.51", features = [
     "formatting",
     "local-offset",
     "parsing",

--- a/README.md
+++ b/README.md
@@ -10,12 +10,17 @@ for each feature you have enabled.  These can be referenced with the [`env!`](ht
 - If using one of the git enabled libraries, will emit [`cargo:rerun-if-changed=.git/HEAD`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed).  This is done to ensure any git instructions are regenerated when commits are made.
 - If using one of the git enabled libraries, will emit [`cargo:rerun-if-changed=.git/<path_to_ref>`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed).  This is done to ensure any git instructions are regenerated when commits are made.
 - Can emit [`cargo:warning`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargo-warning) outputs if the
-[`fail_on_error`](EmitBuilder::fail_on_error) feature is not enabled and the requested variable is defaulted through error or
-the [`idempotent`](EmitBuilder::idempotent) flag.
+[`fail_on_error`](EmitBuilder::fail_on_error) feature is not enabled and the requested variable is defaulted through error,
+the [`idempotent`](EmitBuilder::idempotent) flag, or the [`default_on_error`](EmitBuilder::default_on_error) flag.  By default
+a variable that cannot be generated (for example `VERGEN_GIT_*` when building outside a git worktree) is left unset; enable
+`default_on_error` (or set the `VERGEN_DEFAULT_ON_ERROR` environment variable) to emit the idempotent default value instead so
+`env!` keeps compiling.
 - Will emit [`cargo:rerun-if-changed=build.rs`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed)
 to rerun instruction emission if the `build.rs` file changed.
 - Will emit [`cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed)
 to rerun instruction emission if the `VERGEN_IDEMPOTENT` environment variable has changed.
+- Will emit [`cargo:rerun-if-env-changed=VERGEN_DEFAULT_ON_ERROR`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed)
+to rerun instruction emission if the `VERGEN_DEFAULT_ON_ERROR` environment variable has changed.
 - Will emit [`cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed)
 to rerun instruction emission if the `SOURCE_DATE_EPOCH` environment variable has changed.
 

--- a/vergen-git2/src/lib.rs
+++ b/vergen-git2/src/lib.rs
@@ -24,6 +24,8 @@
 //!   to rerun instruction emission if the `build.rs` file changed.
 //! - Will emit [`cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed)
 //!   to rerun instruction emission if the `VERGEN_IDEMPOTENT` environment variable has changed.
+//! - Will emit [`cargo:rerun-if-env-changed=VERGEN_DEFAULT_ON_ERROR`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed)
+//!   to rerun instruction emission if the `VERGEN_DEFAULT_ON_ERROR` environment variable has changed.
 //! - Will emit [`cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed)
 //!   to rerun instruction emission if the `SOURCE_DATE_EPOCH` environment variable has changed.
 //!
@@ -131,6 +133,7 @@
 //! cargo:rerun-if-changed=/home/jozias/projects/rust-lang/vergen-cl/.git/refs/heads/master
 //! cargo:rerun-if-changed=build.rs
 //! cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT
+//! cargo:rerun-if-env-changed=VERGEN_DEFAULT_ON_ERROR
 //! cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
 //! ```
 //!
@@ -195,6 +198,7 @@ let build = Build::builder().build_timestamp(true).build();"
 //! cargo:rerun-if-changed=/home/jozias/projects/rust-lang/vergen-cl/.git/refs/heads/master
 //! cargo:rerun-if-changed=build.rs
 //! cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT
+//! cargo:rerun-if-env-changed=VERGEN_DEFAULT_ON_ERROR
 //! cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
 //! ```
 //!

--- a/vergen-git2/tests/git_output.rs
+++ b/vergen-git2/tests/git_output.rs
@@ -74,6 +74,7 @@ cargo:warning=VERGEN_GIT_SHA set to default
 cargo:warning=VERGEN_GIT_DIRTY set to default
 cargo:rerun-if-changed=build.rs
 cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT
+cargo:rerun-if-env-changed=VERGEN_DEFAULT_ON_ERROR
 cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH"
     });
     static WARNINGS_ONLY_RE_STR: LazyLock<&'static str> = LazyLock::new(|| {
@@ -90,6 +91,7 @@ cargo:warning=Unable to set VERGEN_GIT_SHA
 cargo:warning=Unable to set VERGEN_GIT_DIRTY
 cargo:rerun-if-changed=build.rs
 cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT
+cargo:rerun-if-env-changed=VERGEN_DEFAULT_ON_ERROR
 cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH"
     });
     static GIT_REGEX_INST: LazyLock<Regex> = LazyLock::new(|| {
@@ -194,6 +196,62 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH"
         let output = String::from_utf8_lossy(&stdout_buf);
         assert!(!failed);
         assert!(ALL_IDEM_OUTPUT.is_match(&output));
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn git_all_output_default_on_error() -> Result<()> {
+        let mut stdout_buf = vec![];
+        let mut git2 = Git2::all_git();
+        let _ = git2.at_path(temp_dir());
+        let failed = Emitter::default()
+            .default_on_error()
+            .add_instructions(&git2)?
+            .emit_to(&mut stdout_buf)?;
+        let output = String::from_utf8_lossy(&stdout_buf);
+        assert!(!failed);
+        // Outside a worktree, default_on_error emits the idempotent defaults
+        // (same as idempotent) rather than leaving the vars unset.
+        assert!(ALL_IDEM_OUTPUT.is_match(&output));
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn git_all_output_default_on_error_env() -> Result<()> {
+        with_var("VERGEN_DEFAULT_ON_ERROR", Some("true"), || {
+            let mut stdout_buf = vec![];
+            let mut git2 = Git2::all_git();
+            let _ = git2.at_path(temp_dir());
+            let failed = Emitter::default()
+                .add_instructions(&git2)
+                .unwrap()
+                .emit_to(&mut stdout_buf)
+                .unwrap();
+            let output = String::from_utf8_lossy(&stdout_buf);
+            assert!(!failed);
+            assert!(ALL_IDEM_OUTPUT.is_match(&output));
+        });
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn git_all_output_default_on_error_test_repo() -> Result<()> {
+        // Inside a real worktree, default_on_error has no effect: the real git
+        // values are still emitted.
+        let repo = TestRepos::new(true, true, false)?;
+        let mut stdout_buf = vec![];
+        let mut git2 = Git2::all().describe(true, false, None).build();
+        let _ = git2.at_path(repo.path());
+        let failed = Emitter::default()
+            .default_on_error()
+            .add_instructions(&git2)?
+            .emit_to(&mut stdout_buf)?;
+        assert!(!failed);
+        let output = String::from_utf8_lossy(&stdout_buf);
+        assert!(GIT_REGEX_INST.is_match(&output));
         Ok(())
     }
 

--- a/vergen-gitcl/src/gitcl/mod.rs
+++ b/vergen-gitcl/src/gitcl/mod.rs
@@ -198,6 +198,7 @@ const DIRTY: &str = dirty!();
 /// cargo:warning=VERGEN_GIT_SHA set to default
 /// cargo:rerun-if-changed=build.rs
 /// cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT
+/// cargo:rerun-if-env-changed=VERGEN_DEFAULT_ON_ERROR
 /// cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
 /// ```
 ///

--- a/vergen-gitcl/src/lib.rs
+++ b/vergen-gitcl/src/lib.rs
@@ -24,6 +24,8 @@
 //!   to rerun instruction emission if the `build.rs` file changed.
 //! - Will emit [`cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed)
 //!   to rerun instruction emission if the `VERGEN_IDEMPOTENT` environment variable has changed.
+//! - Will emit [`cargo:rerun-if-env-changed=VERGEN_DEFAULT_ON_ERROR`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed)
+//!   to rerun instruction emission if the `VERGEN_DEFAULT_ON_ERROR` environment variable has changed.
 //! - Will emit [`cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed)
 //!   to rerun instruction emission if the `SOURCE_DATE_EPOCH` environment variable has changed.
 //!
@@ -131,6 +133,7 @@
 //! cargo:rerun-if-changed=/home/jozias/projects/rust-lang/vergen-cl/.git/refs/heads/master
 //! cargo:rerun-if-changed=build.rs
 //! cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT
+//! cargo:rerun-if-env-changed=VERGEN_DEFAULT_ON_ERROR
 //! cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
 //! ```
 //!
@@ -195,6 +198,7 @@ let build = Build::builder().build_timestamp(true).build();"
 //! cargo:rerun-if-changed=/home/jozias/projects/rust-lang/vergen-cl/.git/refs/heads/master
 //! cargo:rerun-if-changed=build.rs
 //! cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT
+//! cargo:rerun-if-env-changed=VERGEN_DEFAULT_ON_ERROR
 //! cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
 //! ```
 //!

--- a/vergen-gitcl/tests/git_output.rs
+++ b/vergen-gitcl/tests/git_output.rs
@@ -73,6 +73,7 @@ cargo:warning=VERGEN_GIT_SHA set to default
 cargo:warning=VERGEN_GIT_DIRTY set to default
 cargo:rerun-if-changed=build.rs
 cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT
+cargo:rerun-if-env-changed=VERGEN_DEFAULT_ON_ERROR
 cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH"
     });
     static WARNINGS_ONLY_RE_STR: LazyLock<&'static str> = LazyLock::new(|| {
@@ -89,6 +90,7 @@ cargo:warning=Unable to set VERGEN_GIT_SHA
 cargo:warning=Unable to set VERGEN_GIT_DIRTY
 cargo:rerun-if-changed=build.rs
 cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT
+cargo:rerun-if-env-changed=VERGEN_DEFAULT_ON_ERROR
 cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH"
     });
     static GIT_REGEX_INST: LazyLock<Regex> = LazyLock::new(|| {
@@ -191,6 +193,62 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH"
         let output = String::from_utf8_lossy(&stdout_buf);
         assert!(!failed);
         assert!(ALL_IDEM_OUTPUT.is_match(&output));
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn git_all_output_default_on_error() -> Result<()> {
+        let mut stdout_buf = vec![];
+        let mut gitcl = Gitcl::all_git();
+        let _ = gitcl.at_path(temp_dir());
+        let failed = Emitter::default()
+            .default_on_error()
+            .add_instructions(&gitcl)?
+            .emit_to(&mut stdout_buf)?;
+        let output = String::from_utf8_lossy(&stdout_buf);
+        assert!(!failed);
+        // Outside a worktree, default_on_error emits the idempotent defaults
+        // (same as idempotent) rather than leaving the vars unset.
+        assert!(ALL_IDEM_OUTPUT.is_match(&output));
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn git_all_output_default_on_error_env() -> Result<()> {
+        with_var("VERGEN_DEFAULT_ON_ERROR", Some("true"), || {
+            let mut stdout_buf = vec![];
+            let mut gitcl = Gitcl::all_git();
+            let _ = gitcl.at_path(temp_dir());
+            let failed = Emitter::default()
+                .add_instructions(&gitcl)
+                .unwrap()
+                .emit_to(&mut stdout_buf)
+                .unwrap();
+            let output = String::from_utf8_lossy(&stdout_buf);
+            assert!(!failed);
+            assert!(ALL_IDEM_OUTPUT.is_match(&output));
+        });
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn git_all_output_default_on_error_test_repo() -> Result<()> {
+        // Inside a real worktree, default_on_error has no effect: the real git
+        // values are still emitted.
+        let repo = TestRepos::new(true, true, false)?;
+        let mut stdout_buf = vec![];
+        let mut gitcl = Gitcl::all().describe(true, false, None).build();
+        let _ = gitcl.at_path(repo.path());
+        let failed = Emitter::default()
+            .default_on_error()
+            .add_instructions(&gitcl)?
+            .emit_to(&mut stdout_buf)?;
+        assert!(!failed);
+        let output = String::from_utf8_lossy(&stdout_buf);
+        assert!(GIT_REGEX_INST.is_match(&output));
         Ok(())
     }
 

--- a/vergen-gix/src/lib.rs
+++ b/vergen-gix/src/lib.rs
@@ -24,6 +24,8 @@
 //!   to rerun instruction emission if the `build.rs` file changed.
 //! - Will emit [`cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed)
 //!   to rerun instruction emission if the `VERGEN_IDEMPOTENT` environment variable has changed.
+//! - Will emit [`cargo:rerun-if-env-changed=VERGEN_DEFAULT_ON_ERROR`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed)
+//!   to rerun instruction emission if the `VERGEN_DEFAULT_ON_ERROR` environment variable has changed.
 //! - Will emit [`cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed)
 //!   to rerun instruction emission if the `SOURCE_DATE_EPOCH` environment variable has changed.
 //!
@@ -131,6 +133,7 @@
 //! cargo:rerun-if-changed=/home/jozias/projects/rust-lang/vergen-cl/.git/refs/heads/master
 //! cargo:rerun-if-changed=build.rs
 //! cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT
+//! cargo:rerun-if-env-changed=VERGEN_DEFAULT_ON_ERROR
 //! cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
 //! ```
 //!
@@ -195,6 +198,7 @@ let build = Build::builder().build_timestamp(true).build();"
 //! cargo:rerun-if-changed=/home/jozias/projects/rust-lang/vergen-cl/.git/refs/heads/master
 //! cargo:rerun-if-changed=build.rs
 //! cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT
+//! cargo:rerun-if-env-changed=VERGEN_DEFAULT_ON_ERROR
 //! cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
 //! ```
 //!

--- a/vergen-gix/tests/git_output.rs
+++ b/vergen-gix/tests/git_output.rs
@@ -73,6 +73,7 @@ cargo:warning=VERGEN_GIT_SHA set to default
 cargo:warning=VERGEN_GIT_DIRTY set to default
 cargo:rerun-if-changed=build.rs
 cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT
+cargo:rerun-if-env-changed=VERGEN_DEFAULT_ON_ERROR
 cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH"
     });
     static WARNINGS_ONLY_RE_STR: LazyLock<&'static str> = LazyLock::new(|| {
@@ -89,6 +90,7 @@ cargo:warning=Unable to set VERGEN_GIT_SHA
 cargo:warning=Unable to set VERGEN_GIT_DIRTY
 cargo:rerun-if-changed=build.rs
 cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT
+cargo:rerun-if-env-changed=VERGEN_DEFAULT_ON_ERROR
 cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH"
     });
     static GIT_REGEX_INST: LazyLock<Regex> = LazyLock::new(|| {
@@ -193,6 +195,62 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH"
         let output = String::from_utf8_lossy(&stdout_buf);
         assert!(!failed);
         assert!(ALL_IDEM_OUTPUT.is_match(&output));
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn git_all_output_default_on_error() -> Result<()> {
+        let mut stdout_buf = vec![];
+        let mut gix = Gix::all_git();
+        let _ = gix.at_path(temp_dir());
+        let failed = Emitter::default()
+            .default_on_error()
+            .add_instructions(&gix)?
+            .emit_to(&mut stdout_buf)?;
+        let output = String::from_utf8_lossy(&stdout_buf);
+        assert!(!failed);
+        // Outside a worktree, default_on_error emits the idempotent defaults
+        // (same as idempotent) rather than leaving the vars unset.
+        assert!(ALL_IDEM_OUTPUT.is_match(&output));
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn git_all_output_default_on_error_env() -> Result<()> {
+        with_var("VERGEN_DEFAULT_ON_ERROR", Some("true"), || {
+            let mut stdout_buf = vec![];
+            let mut gix = Gix::all_git();
+            let _ = gix.at_path(temp_dir());
+            let failed = Emitter::default()
+                .add_instructions(&gix)
+                .unwrap()
+                .emit_to(&mut stdout_buf)
+                .unwrap();
+            let output = String::from_utf8_lossy(&stdout_buf);
+            assert!(!failed);
+            assert!(ALL_IDEM_OUTPUT.is_match(&output));
+        });
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn git_all_output_default_on_error_test_repo() -> Result<()> {
+        // Inside a real worktree, default_on_error has no effect: the real git
+        // values are still emitted.
+        let repo = TestRepos::new(true, true, false)?;
+        let mut stdout_buf = vec![];
+        let mut gix = Gix::all_git();
+        let _ = gix.at_path(repo.path());
+        let failed = Emitter::default()
+            .default_on_error()
+            .add_instructions(&gix)?
+            .emit_to(&mut stdout_buf)?;
+        assert!(!failed);
+        let output = String::from_utf8_lossy(&stdout_buf);
+        assert!(GIT_REGEX_INST.is_match(&output));
         Ok(())
     }
 

--- a/vergen-lib/src/emitter.rs
+++ b/vergen-lib/src/emitter.rs
@@ -17,8 +17,10 @@ use std::{
 /// The `Emitter` will emit cargo instructions (i.e. cargo:rustc-env=NAME=VALUE)
 /// base on the configuration you enable.
 #[derive(Clone, Debug, PartialEq)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct Emitter {
     idempotent: bool,
+    default_on_error: bool,
     fail_on_error: bool,
     quiet: bool,
     custom_buildrs: Option<&'static str>,
@@ -65,6 +67,7 @@ impl Emitter {
     pub fn new() -> Self {
         Self {
             idempotent: matches!(env::var("VERGEN_IDEMPOTENT"), Ok(_val)),
+            default_on_error: matches!(env::var("VERGEN_DEFAULT_ON_ERROR"), Ok(_val)),
             fail_on_error: false,
             quiet: false,
             custom_buildrs: None,
@@ -94,6 +97,13 @@ impl Emitter {
     /// | `VERGEN_BUILD_DATE` | `VERGEN_IDEMPOTENT_OUTPUT` |
     /// | `VERGEN_BUILD_TIMESTAMP` | `VERGEN_IDEMPOTENT_OUTPUT` |
     ///
+    /// **NOTE** - This feature **always** forces idempotent output, even when the
+    /// requested instructions *could* be generated normally (e.g. inside a real git
+    /// worktree).  Use it only when you want deterministic builds.  If you instead
+    /// want real values when they are available but a default placeholder only when
+    /// generation fails (e.g. building outside a git worktree), use
+    /// [`default_on_error`](Self::default_on_error) instead.
+    ///
     /// # Example
     ///
     /// ```
@@ -119,18 +129,65 @@ impl Emitter {
         self
     }
 
+    /// Enable the `default_on_error` feature
+    ///
+    /// **NOTE** - This feature can also be enabled via the `VERGEN_DEFAULT_ON_ERROR`
+    /// environment variable.
+    ///
+    /// By default, if `vergen` cannot generate a requested instruction (for example
+    /// when you configure `VERGEN_GIT_*` instructions but build from a source tarball
+    /// with no `.git` directory), the variable is left **unset** and only a
+    /// [`cargo:warning`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargo-warning)
+    /// is emitted.  This means a downstream `env!("VERGEN_GIT_SHA")` will fail to
+    /// compile.
+    ///
+    /// When this feature is enabled, those un-generatable instructions are instead
+    /// populated with the idempotent default value (`VERGEN_IDEMPOTENT_OUTPUT`), so
+    /// `env!()` keeps compiling.  Unlike [`idempotent`](Self::idempotent), this only
+    /// affects the fallback path: when the instructions *can* be generated (e.g. inside
+    /// a real git worktree) you still get the real values.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use anyhow::Result;
+    /// # use vergen_lib::Emitter;
+    /// #
+    /// # fn main() -> Result<()> {
+    /// Emitter::new().default_on_error().emit()?;
+    /// // or
+    /// #     temp_env::with_var("VERGEN_DEFAULT_ON_ERROR", Some("true"), || {
+    /// #         let result = || -> Result<()> {
+    /// // set::env("VERGEN_DEFAULT_ON_ERROR", "true");
+    /// Emitter::new().emit()?;
+    /// #         Ok(())
+    /// #         }();
+    /// #     });
+    /// #     Ok(())
+    /// # }
+    /// ```
+    ///
+    pub fn default_on_error(&mut self) -> &mut Self {
+        self.default_on_error = true;
+        self
+    }
+
     /// Enable the `fail_on_error` feature
     ///
     /// By default `vergen` will emit the instructions you requested.  If for some
-    /// reason those instructions cannot be generated correctly, placeholder values
-    /// will be used instead.   `vergen` will also emit [`cargo:warning`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargo-warning)
+    /// reason those instructions cannot be generated correctly, the affected variables
+    /// are left unset (unless [`idempotent`](Self::idempotent) or
+    /// [`default_on_error`](Self::default_on_error) is enabled, in which case they are
+    /// populated with the idempotent default value).  `vergen` will also emit
+    /// [`cargo:warning`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargo-warning)
     /// instructions notifying you this has happened.
     ///
     /// For example, if you configure `vergen` to emit `VERGEN_GIT_*` instructions and
     /// you run a build from a source tarball with no `.git` directory, the instructions
-    /// will be populated with placeholder values, rather than information gleaned through git.
+    /// will be skipped (or defaulted, per above), rather than information gleaned through
+    /// git.
     ///
-    /// You can turn off this behavior by enabling `fail_on_error`.
+    /// When `fail_on_error` is enabled, that situation produces a hard error instead.
     ///
     /// # Example
     ///
@@ -203,7 +260,11 @@ impl Emitter {
                 &mut self.cargo_warning,
             )
             .or_else(|e| {
-                let default_config = DefaultConfig::new(self.idempotent, self.fail_on_error, e);
+                let default_config = DefaultConfig::new(
+                    self.idempotent || self.default_on_error,
+                    self.fail_on_error,
+                    e,
+                );
                 entries.add_default_entries(
                     &default_config,
                     &mut self.cargo_rustc_env_map,
@@ -237,7 +298,11 @@ impl Emitter {
                 &mut self.cargo_warning,
             )
             .or_else(|e| {
-                let default_config = DefaultConfig::new(self.idempotent, self.fail_on_error, e);
+                let default_config = DefaultConfig::new(
+                    self.idempotent || self.default_on_error,
+                    self.fail_on_error,
+                    e,
+                );
                 custom_entries.add_default_entries(
                     &default_config,
                     &mut map,
@@ -300,6 +365,7 @@ impl Emitter {
             let sanitized_output = Self::filter_newlines(buildrs);
             writeln!(stdout, "cargo:rerun-if-changed={sanitized_output}")?;
             writeln!(stdout, "cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT")?;
+            writeln!(stdout, "cargo:rerun-if-env-changed=VERGEN_DEFAULT_ON_ERROR")?;
             writeln!(stdout, "cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH")?;
         }
         Ok(())
@@ -373,6 +439,7 @@ impl Emitter {
     /// cargo:rerun-if-changed=.git/refs/heads/feature/version8
     /// cargo:rerun-if-changed=build.rs
     /// cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT
+    /// cargo:rerun-if-env-changed=VERGEN_DEFAULT_ON_ERROR
     /// cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
     /// ```
     ///
@@ -480,5 +547,26 @@ pub(crate) mod test {
     #[serial]
     fn default_emit_is_ok() {
         assert!(Emitter::new().emit().is_ok());
+    }
+
+    #[test]
+    #[serial]
+    fn default_on_error_emit_is_ok() {
+        assert!(Emitter::new().default_on_error().emit().is_ok());
+    }
+
+    #[test]
+    #[serial]
+    fn default_on_error_populates_fallback() -> Result<()> {
+        use crate::entries::test_gen::CustomInsGen;
+        let custom = CustomInsGen::builder().fail(true).build();
+        let mut stdout_buf = vec![];
+        _ = Emitter::new()
+            .default_on_error()
+            .add_custom_instructions(&custom)?
+            .emit_to(&mut stdout_buf)?;
+        let output = String::from_utf8_lossy(&stdout_buf);
+        assert!(output.contains("VERGEN_IDEMPOTENT_OUTPUT"));
+        Ok(())
     }
 }

--- a/vergen/Cargo.toml
+++ b/vergen/Cargo.toml
@@ -39,7 +39,7 @@ bon = { workspace = true }
 cargo_metadata = { version = "0.23.1", optional = true }
 regex = { workspace = true, optional = true }
 rustc_version = { version = "0.4.1", optional = true }
-sysinfo = { version = "0.39.3", optional = true }
+sysinfo = { version = "0.39.5", optional = true }
 time = { workspace = true, optional = true }
 vergen-lib = { version = "10.0.1", path = "../vergen-lib" }
 

--- a/vergen/src/feature/build.rs
+++ b/vergen/src/feature/build.rs
@@ -140,6 +140,7 @@ use vergen_lib::{
 /// cargo:warning=VERGEN_BUILD_TIMESTAMP set to default
 /// cargo:rerun-if-changed=build.rs
 /// cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT
+/// cargo:rerun-if-env-changed=VERGEN_DEFAULT_ON_ERROR
 /// cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
 /// ```
 ///

--- a/vergen/src/feature/si.rs
+++ b/vergen/src/feature/si.rs
@@ -148,6 +148,7 @@ use vergen_lib::{
 /// cargo:warning=VERGEN_SYSINFO_CPU_FREQUENCY set to default
 /// cargo:rerun-if-changed=build.rs
 /// cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT
+/// cargo:rerun-if-env-changed=VERGEN_DEFAULT_ON_ERROR
 /// cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
 /// ```
 ///

--- a/vergen/src/lib.rs
+++ b/vergen/src/lib.rs
@@ -18,6 +18,8 @@
 //!   to rerun instruction emission if the `build.rs` file changed.
 //! - Will emit [`cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed)
 //!   to rerun instruction emission if the `VERGEN_IDEMPOTENT` environment variable has changed.
+//! - Will emit [`cargo:rerun-if-env-changed=VERGEN_DEFAULT_ON_ERROR`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed)
+//!   to rerun instruction emission if the `VERGEN_DEFAULT_ON_ERROR` environment variable has changed.
 //! - Will emit [`cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH`](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed)
 //!   to rerun instruction emission if the `SOURCE_DATE_EPOCH` environment variable has changed.
 //! - Will emit custom instructions via the [`AddCustomEntries`] and the [`add_custom_instructions`](Emitter::add_custom_instructions) function.
@@ -112,6 +114,7 @@
 //! cargo:rustc-env=VERGEN_SYSINFO_CPU_FREQUENCY=3792
 //! cargo:rerun-if-changed=build.rs
 //! cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT
+//! cargo:rerun-if-env-changed=VERGEN_DEFAULT_ON_ERROR
 //! cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
 //! ```
 //!
@@ -171,6 +174,7 @@ let build = Build::builder().build_timestamp(true).build();"
 //! cargo:rustc-env=VERGEN_SYSINFO_CPU_CORE_COUNT=8
 //! cargo:rerun-if-changed=build.rs
 //! cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT
+//! cargo:rerun-if-env-changed=VERGEN_DEFAULT_ON_ERROR
 //! cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
 //! ```
 //!
@@ -210,7 +214,8 @@ let build = Build::builder().build_timestamp(true).build();"
 //!
 //! | Variable | Functionality |
 //! | -------- | ------------- |
-//! | `VERGEN_IDEMPOTENT` | If this environment variable is set `vergen` will use the idempotent output feature regardless of the configuration set in `build.rs`.  This exists mainly to allow package maintainers to force idempotent output to generate deterministic binary output. |
+//! | `VERGEN_IDEMPOTENT` | If this environment variable is set `vergen` will **always** use the idempotent output feature regardless of the configuration set in `build.rs`, even when the requested values could be generated normally.  This exists mainly to allow package maintainers to force idempotent output to generate deterministic binary output. |
+//! | `VERGEN_DEFAULT_ON_ERROR` | If this environment variable is set `vergen` will emit the idempotent default value for any instruction it cannot otherwise generate (e.g. `VERGEN_GIT_*` when building outside a git worktree), rather than leaving the variable unset.  Unlike `VERGEN_IDEMPOTENT`, values that *can* be generated are still emitted normally. |
 //! | `SOURCE_DATE_EPOCH` | If this environment variable is set `vergen` will use the value (unix time since epoch) as the basis for a time based instructions.  This can help emit deterministic instructions. |
 //! | `VERGEN_BUILD_*` | If this environment variable is set `vergen` will use the value you specify for the output rather than generating it. |
 //! | `VERGEN_CARGO_*` | If this environment variable is set `vergen` will use the value you specify for the output rather than generating it. |

--- a/vergen/tests/build_output.rs
+++ b/vergen/tests/build_output.rs
@@ -48,6 +48,7 @@ cargo:warning=VERGEN_BUILD_DATE set to default
 cargo:warning=VERGEN_BUILD_TIMESTAMP set to default
 cargo:rerun-if-changed=build.rs
 cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT
+cargo:rerun-if-env-changed=VERGEN_DEFAULT_ON_ERROR
 cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
 ";
 
@@ -57,6 +58,7 @@ cargo:warning=VERGEN_BUILD_DATE set to default
 cargo:warning=VERGEN_BUILD_TIMESTAMP set to default
 cargo:rerun-if-changed=a/custom_build.rs
 cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT
+cargo:rerun-if-env-changed=VERGEN_DEFAULT_ON_ERROR
 cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
 ";
 
@@ -64,6 +66,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
 cargo:rustc-env=VERGEN_BUILD_TIMESTAMP=2022-12-23T15:29:20.000000000Z
 cargo:rerun-if-changed=build.rs
 cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT
+cargo:rerun-if-env-changed=VERGEN_DEFAULT_ON_ERROR
 cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
 ";
 
@@ -71,6 +74,7 @@ cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
 cargo:rustc-env=VERGEN_BUILD_TIMESTAMP=VERGEN_IDEMPOTENT_OUTPUT
 cargo:rerun-if-changed=build.rs
 cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT
+cargo:rerun-if-env-changed=VERGEN_DEFAULT_ON_ERROR
 cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
 ";
 

--- a/vergen/tests/sysinfo_output.rs
+++ b/vergen/tests/sysinfo_output.rs
@@ -52,6 +52,7 @@ cargo:warning=VERGEN_SYSINFO_CPU_BRAND set to default
 cargo:warning=VERGEN_SYSINFO_CPU_FREQUENCY set to default
 cargo:rerun-if-changed=build.rs
 cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT
+cargo:rerun-if-env-changed=VERGEN_DEFAULT_ON_ERROR
 cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
 ";
 
@@ -66,6 +67,7 @@ cargo:rustc-env=VERGEN_SYSINFO_CPU_BRAND=VERGEN_IDEMPOTENT_OUTPUT
 cargo:rustc-env=VERGEN_SYSINFO_CPU_FREQUENCY=VERGEN_IDEMPOTENT_OUTPUT
 cargo:rerun-if-changed=build.rs
 cargo:rerun-if-env-changed=VERGEN_IDEMPOTENT
+cargo:rerun-if-env-changed=VERGEN_DEFAULT_ON_ERROR
 cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH
 ";
 


### PR DESCRIPTION
## Summary

`v10.0.1` enhancements bundling a new git fallback knob, dependency bumps, and a security-audit refresh.

### `VERGEN_DEFAULT_ON_ERROR` fallback (#508)

Since v10, building outside a git worktree (or any time an instruction cannot be generated) leaves the `VERGEN_*` variables **unset** rather than emitting a default, which breaks downstream `env!("VERGEN_GIT_SHA")` at compile time. The existing `idempotent` flag restores the defaults but is all-or-nothing — it also forces placeholder values *inside* a real worktree.

This adds a fallback-scoped knob:
- New `VERGEN_DEFAULT_ON_ERROR` environment variable.
- New `Emitter::default_on_error()` builder method.

When enabled, instructions that cannot be generated are populated with the idempotent default (`VERGEN_IDEMPOTENT_OUTPUT`, warned as `set to default`) so `env!()` keeps compiling — while builds **inside** a real worktree still emit the real values (the flag only affects the error/fallback path).

Also:
- Corrected the now-inaccurate `fail_on_error` docs (by default missing vars are left unset, not defaulted).
- Clarified that `idempotent` **always** forces idempotent output.
- Emits `cargo:rerun-if-changed=VERGEN_DEFAULT_ON_ERROR` and documents the new variable in the env-var table / READMEs.
- Added fallback + in-worktree no-op tests across `vergen-gitcl`, `vergen-git2`, and `vergen-gix`.

### Dependency updates
- `bon` 3.9.1 → 3.9.3
- `gix` 0.84.0 → 0.85.0
- `regex` 1.12.3 → 1.12.4
- `time` 0.3.47 → 0.3.51
- `sysinfo` 0.39.3 → 0.39.5 (vergen crate)
- `memmap2` 0.9.10 → 0.9.11 (resolves the unsound **RUSTSEC-2026-0186**; picked up via the untracked lockfile)

### Security audit refresh (`.cargo/audit.toml`)
- **Add** `RUSTSEC-2026-0173` — `proc-macro-error2` is unmaintained (informational only, no patched version, pulled in transitively via `gix` → `jiff` → `defmt`; nothing actionable on our end).
- **Remove** `RUSTSEC-2025-0055` — `tracing-subscriber` is fixed; the tree now resolves to 0.3.23 (≥ 0.3.20 patched).
- **Remove** `RUSTSEC-2025-0141` — `bincode` is no longer in the dependency tree.

`cargo audit` now passes clean.

Closes #506, #507, #510, #511, #512

🤖 Generated with [Claude Code](https://claude.com/claude-code)
