### PR TITLE
chore: add Rakefile.toml build pipeline and fix doc references

### DIFF
--- a/Rakefile.toml
+++ b/Rakefile.toml
@@ -1,0 +1,198 @@
+# =============================================================================
+# Rakefile.toml — vergen workspace build pipeline
+#
+# Quick reference:
+#
+#   cargo rake                           default (most: fmt→clippy→build→test→coverage→docs)
+#   cargo rake most ^coverage            skip coverage
+#   cargo rake most ^docs                skip docs
+#   cargo rake most clean                add cargo clean
+#   cargo rake all                       everything (puc + most + clean)
+#   cargo rake daily                     alias for all (morning full-pipeline run)
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# tools
+# ---------------------------------------------------------------------------
+
+[tool.cargo.matrix]
+crate = "cargo-matrix"
+check = ["cargo", "matrix", "--version"]
+install = ["cargo", "install", "cargo-matrix", "--force", "--locked"]
+update = true
+
+[tool.cargo.llvm-cov]
+crate = "cargo-llvm-cov"
+check = ["cargo", "llvm-cov", "--version"]
+install = ["cargo", "install", "cargo-llvm-cov", "--force", "--locked"]
+update = true
+
+[tool.fish.puc]
+hint = "The 'puc' fish function is required to run this target"
+
+# ---------------------------------------------------------------------------
+# update
+# ---------------------------------------------------------------------------
+
+[target.puc]
+tools = ["puc"]
+[[target.puc.command]]
+name = "puc"
+platform = ["linux"]
+fish = "puc"
+
+# ---------------------------------------------------------------------------
+# fmt
+# ---------------------------------------------------------------------------
+
+[[target.fmt.command]]
+name = "fmt"
+cmd = ["cargo", "fmt"]
+
+[[target.fmt.command]]
+name = "fmt check"
+cmd = ["cargo", "fmt", "--all", "--", "--check"]
+
+# ---------------------------------------------------------------------------
+# clippy
+# ---------------------------------------------------------------------------
+
+[target.clippy]
+tools = ["matrix"]
+
+[[target.clippy.command]]
+name = "clippy"
+cmd = ["cargo", "matrix", "-c", "nightly", "clippy", "--all-targets", "--", "-Dwarnings"]
+
+# ---------------------------------------------------------------------------
+# build
+# ---------------------------------------------------------------------------
+
+[target.build]
+tools = ["matrix"]
+
+[[target.build.command]]
+name = "build"
+cmd = ["cargo", "matrix", "build"]
+
+# ---------------------------------------------------------------------------
+# test
+# ---------------------------------------------------------------------------
+
+[target.test]
+depends_on = ["build"]
+tools = ["matrix"]
+
+[[target.test.command]]
+name = "test"
+cmd = ["cargo", "matrix", "test"]
+
+# ---------------------------------------------------------------------------
+# coverage
+# ---------------------------------------------------------------------------
+
+[target.coverage]
+depends_on = ["test"]
+tools = ["llvm-cov", "matrix"]
+
+[[target.coverage.command]]
+name = "llvm-cov clean"
+cmd = ["cargo", "llvm-cov", "clean", "--workspace"]
+
+[[target.coverage.command]]
+name = "vergen-lib"
+cmd = ["cargo", "matrix", "-c", "llvm-cov", "-p", "vergen-lib", "--manifest-path", "vergen-lib/Cargo.toml", "llvm-cov", "--no-report"]
+
+[[target.coverage.command]]
+name = "vergen"
+cmd = ["cargo", "matrix", "-c", "nightly", "-p", "vergen", "--manifest-path", "vergen/Cargo.toml", "llvm-cov", "--no-report"]
+
+[[target.coverage.command]]
+name = "vergen-git2"
+cmd = ["cargo", "matrix", "-c", "nightly", "-p", "vergen-git2", "--manifest-path", "vergen-git2/Cargo.toml", "llvm-cov", "--no-report"]
+
+[[target.coverage.command]]
+name = "vergen-gitcl"
+cmd = ["cargo", "matrix", "-c", "nightly", "-p", "vergen-gitcl", "--manifest-path", "vergen-gitcl/Cargo.toml", "llvm-cov", "--no-report"]
+
+[[target.coverage.command]]
+name = "vergen-gix"
+cmd = ["cargo", "matrix", "-c", "nightly", "-p", "vergen-gix", "--manifest-path", "vergen-gix/Cargo.toml", "llvm-cov", "--no-report"]
+
+[[target.coverage.command]]
+name = "vergen-pretty"
+cmd = ["cargo", "matrix", "-c", "nightly", "-p", "vergen-pretty", "--manifest-path", "vergen-pretty/Cargo.toml", "llvm-cov", "--no-report"]
+
+[[target.coverage.command]]
+name = "vergen-pretty empty"
+cmd = ["cargo", "matrix", "-c", "nightly-empty", "-p", "vergen-pretty", "--manifest-path", "vergen-pretty/Cargo.toml", "llvm-cov", "--no-report"]
+
+[[target.coverage.command]]
+name = "lcov.info"
+cmd = ["cargo", "llvm-cov", "report", "--lcov", "--output-path", "lcov.info"]
+
+[[target.coverage.command]]
+name = "html"
+cmd = ["cargo", "llvm-cov", "report", "--html"]
+
+# ---------------------------------------------------------------------------
+# docs
+# ---------------------------------------------------------------------------
+
+[[target.docs.command]]
+name = "test_util"
+cmd = ["cargo", "doc", "-p", "test_util", "-F", "repo"]
+
+[[target.docs.command]]
+name = "vergen-lib"
+cmd = ["cargo", "doc", "-p", "vergen-lib", "-F", "build,cargo,git,rustc,si"]
+
+[[target.docs.command]]
+name = "vergen"
+cmd = ["cargo", "doc", "-p", "vergen", "-F", "build,cargo,emit_and_set,rustc,si"]
+
+[[target.docs.command]]
+name = "vergen-git2"
+cmd = ["cargo", "doc", "-p", "vergen-git2", "-F", "build,cargo,emit_and_set,rustc,si"]
+
+[[target.docs.command]]
+name = "vergen-gitcl"
+cmd = ["cargo", "doc", "-p", "vergen-gitcl", "-F", "build,cargo,emit_and_set,rustc,si"]
+
+[[target.docs.command]]
+name = "vergen-gix"
+cmd = ["cargo", "doc", "-p", "vergen-gix", "-F", "build,cargo,emit_and_set,rustc,si"]
+
+[[target.docs.command]]
+name = "vergen-pretty"
+cmd = ["cargo", "doc", "-p", "vergen-pretty", "-F", "color,header,trace"]
+
+# ---------------------------------------------------------------------------
+# clean
+# ---------------------------------------------------------------------------
+
+[[target.clean.command]]
+name = "clean"
+cmd = ["cargo", "clean"]
+
+[[target.clean.command]]
+name = "rm lcov.info"
+fish = "rm -f lcov.info"
+sh = "rm -f lcov.info"
+ps = "Remove-Item -Force lcov.info -ErrorAction Ignore"
+
+# ---------------------------------------------------------------------------
+# aggregates
+# ---------------------------------------------------------------------------
+
+[target.most]
+depends_on = ["fmt", "clippy", "build", "test", "coverage", "docs"]
+
+[target.all]
+depends_on = ["puc", "fmt", "clippy", "build", "test", "coverage", "docs", "clean"]
+
+[target.daily]
+depends_on = ["all"]
+
+[target.default]
+depends_on = ["most"]

--- a/Rakefile.toml
+++ b/Rakefile.toml
@@ -34,12 +34,20 @@ hint = "The 'puc' fish function is required to run this target"
 # update
 # ---------------------------------------------------------------------------
 
-[target.puc]
+[target.puc.linux]
 tools = ["puc"]
-[[target.puc.command]]
+
+[[target.puc.linux.command]]
 name = "puc"
-platform = ["linux"]
 fish = "puc"
+
+[[target.puc.command]]
+name = "pull"
+cmd = ["git", "pull"]
+
+[[target.puc.command]]
+name = "puc clean"
+cmd = ["cargo", "clean"]
 
 # ---------------------------------------------------------------------------
 # fmt
@@ -193,6 +201,12 @@ depends_on = ["puc", "fmt", "clippy", "build", "test", "coverage", "docs", "clea
 
 [target.daily]
 depends_on = ["all"]
+
+[target.daily.windows]
+depends_on = ["puc", "fmt", "clippy"]
+
+[target.daily.macos]
+depends_on = ["puc", "fmt", "clippy"]
 
 [target.default]
 depends_on = ["most"]

--- a/vergen-lib/src/entries.rs
+++ b/vergen-lib/src/entries.rs
@@ -123,7 +123,7 @@ pub trait Add {
 ///     }
 /// }
 /// ```
-/// ## Then in [`build.rs`]
+/// ## Then in build.rs
 ///
 /// ```will_not_compile
 /// let build = BuildBuilder::all_build()?;

--- a/vergen/src/feature/build.rs
+++ b/vergen/src/feature/build.rs
@@ -192,7 +192,7 @@ impl Build {
         Self::builder().all().build()
     }
 
-    /// Convenience method to setup the [`Build`] builder with all of the `VERGEN_BUILD_*` instructions on
+    /// Convenience method to setup the builder with all of the `VERGEN_BUILD_*` instructions on
     pub fn all() -> BuildBuilder<Empty> {
         Self::builder().all()
     }

--- a/vergen/src/feature/cargo.rs
+++ b/vergen/src/feature/cargo.rs
@@ -199,7 +199,7 @@ impl Cargo {
         Self::builder().all().build()
     }
 
-    /// Convenience method to setup the [`Build`] builder with all of the `VERGEN_CARGO_*` instructions on
+    /// Convenience method to setup the builder with all of the `VERGEN_CARGO_*` instructions on
     pub fn all() -> CargoBuilder<Empty> {
         Self::builder().all()
     }

--- a/vergen/src/feature/rustc.rs
+++ b/vergen/src/feature/rustc.rs
@@ -134,7 +134,7 @@ impl Rustc {
         Self::builder().all().build()
     }
 
-    /// Convenience method to setup the [`Rustc`] builder with all of the `VERGEN_RUSTC_*` instructions on
+    /// Convenience method to setup the builder with all of the `VERGEN_RUSTC_*` instructions on
     pub fn all() -> RustcBuilder<Empty> {
         Self::builder().all()
     }

--- a/vergen/src/feature/si.rs
+++ b/vergen/src/feature/si.rs
@@ -217,7 +217,7 @@ impl Sysinfo {
         Self::builder().all().build()
     }
 
-    /// Convenience method to setup the [`Sysinfo`] builder with all of the `VERGEN_SYSINFO_*` instructions on
+    /// Convenience method to setup the builder with all of the `VERGEN_SYSINFO_*` instructions on
     pub fn all() -> SysinfoBuilder<Empty> {
         Self::builder().all()
     }


### PR DESCRIPTION
## Summary

- Adds `Rakefile.toml` — a `cargo-rake` build pipeline configuration for the vergen workspace, covering fmt, clippy, build, test, coverage, docs, and clean targets, with platform-specific variants for Linux, macOS, and Windows
- Fixes doc comments that incorrectly used intra-doc link syntax (`[\`Build\`]`, `[\`build.rs\`]`, etc.) where plain text was intended

🤖 Generated with [Claude Code](https://claude.com/claude-code)