### PR TITLE
chore(rake): add clean to macos daily depends_on

### DIFF
--- a/Rakefile.toml
+++ b/Rakefile.toml
@@ -206,7 +206,7 @@ depends_on = ["all"]
 depends_on = ["puc", "fmt", "clippy"]
 
 [target.daily.macos]
-depends_on = ["puc", "fmt", "clippy"]
+depends_on = ["puc", "fmt", "clippy", "clean"]
 
 [target.default]
 depends_on = ["most"]


### PR DESCRIPTION
## Summary

- Adds `clean` as a dependency of the `macos` variant of the `daily` target in `Rakefile.toml`, matching the intent of a clean-slate daily build on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)