### PR TITLE
chore: replace deprecated provenance lints with implicit_provenance_casts

### DIFF
--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -265,8 +265,7 @@ the [`TestRepos`] struct to creat temporary git repositories useful for `vergen-
 #![cfg_attr(
     all(feature = "unstable", nightly),
     deny(
-        fuzzy_provenance_casts,
-        lossy_provenance_casts,
+        implicit_provenance_casts,
         multiple_supertrait_upcastable,
         must_not_suspend,
         non_exhaustive_omitted_patterns,

--- a/vergen-git2/src/lib.rs
+++ b/vergen-git2/src/lib.rs
@@ -440,8 +440,7 @@ let build = Build::builder().build_timestamp(true).build();"
 #![cfg_attr(
     all(feature = "unstable", nightly),
     deny(
-        fuzzy_provenance_casts,
-        lossy_provenance_casts,
+        implicit_provenance_casts,
         multiple_supertrait_upcastable,
         must_not_suspend,
         non_exhaustive_omitted_patterns,

--- a/vergen-gitcl/src/lib.rs
+++ b/vergen-gitcl/src/lib.rs
@@ -440,8 +440,7 @@ let build = Build::builder().build_timestamp(true).build();"
 #![cfg_attr(
     all(feature = "unstable", nightly),
     deny(
-        fuzzy_provenance_casts,
-        lossy_provenance_casts,
+        implicit_provenance_casts,
         multiple_supertrait_upcastable,
         must_not_suspend,
         non_exhaustive_omitted_patterns,

--- a/vergen-gix/src/lib.rs
+++ b/vergen-gix/src/lib.rs
@@ -440,8 +440,7 @@ let build = Build::builder().build_timestamp(true).build();"
 #![cfg_attr(
     all(feature = "unstable", nightly),
     deny(
-        fuzzy_provenance_casts,
-        lossy_provenance_casts,
+        implicit_provenance_casts,
         multiple_supertrait_upcastable,
         must_not_suspend,
         non_exhaustive_omitted_patterns,

--- a/vergen-lib/src/lib.rs
+++ b/vergen-lib/src/lib.rs
@@ -208,8 +208,7 @@
 #![cfg_attr(
     all(feature = "unstable", nightly),
     deny(
-        fuzzy_provenance_casts,
-        lossy_provenance_casts,
+        implicit_provenance_casts,
         multiple_supertrait_upcastable,
         must_not_suspend,
         non_exhaustive_omitted_patterns,

--- a/vergen-pretty/src/lib.rs
+++ b/vergen-pretty/src/lib.rs
@@ -297,8 +297,7 @@ assert!(!buf.is_empty());
 #![cfg_attr(
     all(feature = "unstable", nightly),
     deny(
-        fuzzy_provenance_casts,
-        lossy_provenance_casts,
+        implicit_provenance_casts,
         multiple_supertrait_upcastable,
         must_not_suspend,
         non_exhaustive_omitted_patterns,

--- a/vergen/src/lib.rs
+++ b/vergen/src/lib.rs
@@ -487,8 +487,7 @@ let build = Build::builder().build_timestamp(true).build();"
 #![cfg_attr(
     all(feature = "unstable", nightly),
     deny(
-        fuzzy_provenance_casts,
-        lossy_provenance_casts,
+        implicit_provenance_casts,
         multiple_supertrait_upcastable,
         must_not_suspend,
         non_exhaustive_omitted_patterns,


### PR DESCRIPTION
## Summary

- Replace `fuzzy_provenance_casts` and `lossy_provenance_casts` nightly lints with the unified `implicit_provenance_casts` lint across all 7 workspace crates
- These two lints were merged into one in nightly Rust; the old names are deprecated and emit warnings

## Test plan

- [ ] `cargo matrix -c nightly clippy --all-targets -- -Dwarnings` passes with no warnings on all crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)