### PR TITLE
chore(deps): dependency updates and Windows lcov fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,21 +12,21 @@ members = [
 ]
 
 [workspace.dependencies]
-anyhow = "1.0.102"
+anyhow = "1.0.104"
 bon = "3.9.3"
-gix = { version = "0.85.0", default-features = false, features = [
+gix = { version = "0.86.0", default-features = false, features = [
     "revision",
     "worktree-mutation",
     "blocking-network-client",
     "sha1",
 ] }
-rand = { version = "0.10.1" }
-regex = { version = "1.12.4" }
-rustversion = "1.0.22"
-serde_json = "1.0.150"
-serial_test = "3.5.0"
+rand = { version = "0.10.2" }
+regex = { version = "1.13.1" }
+rustversion = "1.0.23"
+serde_json = "1.0.151"
+serial_test = "4.0.1"
 temp-env = "0.3.6"
-time = { version = "0.3.51", features = [
+time = { version = "0.3.55", features = [
     "formatting",
     "local-offset",
     "parsing",

--- a/Rakefile.toml
+++ b/Rakefile.toml
@@ -188,7 +188,7 @@ cmd = ["cargo", "clean"]
 name = "rm lcov.info"
 fish = "rm -f lcov.info"
 sh = "rm -f lcov.info"
-ps = "Remove-Item -Force lcov.info -ErrorAction Ignore"
+ps = "if (Test-Path lcov.info) { Remove-Item -Force lcov.info }"
 
 # ---------------------------------------------------------------------------
 # aggregates

--- a/test_util/Cargo.toml
+++ b/test_util/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.96.0"
 name = "test_util"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "10.0.1"
+version = "10.0.2"
 
 [package.metadata.cargo-matrix]
 [[package.metadata.cargo-matrix.channel]]

--- a/vergen-git2/Cargo.toml
+++ b/vergen-git2/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.96.0"
 name = "vergen-git2"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "10.0.1"
+version = "10.0.2"
 
 [package.metadata.cargo-matrix]
 [[package.metadata.cargo-matrix.channel]]
@@ -57,8 +57,8 @@ anyhow = { workspace = true }
 bon = { workspace = true }
 git2-rs = { version = "0.21.0", package = "git2", default-features = false }
 time = { workspace = true }
-vergen = { version = "10.0.1", path = "../vergen", default-features = false }
-vergen-lib = { version = "10.0.1", path = "../vergen-lib", features = [
+vergen = { version = "10.0.2", path = "../vergen", default-features = false }
+vergen-lib = { version = "10.0.2", path = "../vergen-lib", features = [
     "git",
 ] }
 

--- a/vergen-gitcl/Cargo.toml
+++ b/vergen-gitcl/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.96.0"
 name = "vergen-gitcl"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "10.0.1"
+version = "10.0.2"
 
 [package.metadata.cargo-matrix]
 [[package.metadata.cargo-matrix.channel]]
@@ -54,8 +54,8 @@ vcs_info = ["vergen-lib/vcs_info"]
 anyhow = { workspace = true }
 bon = { workspace = true }
 time = { workspace = true }
-vergen = { version = "10.0.1", path = "../vergen", default-features = false }
-vergen-lib = { version = "10.0.1", path = "../vergen-lib", features = ["git"] }
+vergen = { version = "10.0.2", path = "../vergen", default-features = false }
+vergen-lib = { version = "10.0.2", path = "../vergen-lib", features = ["git"] }
 
 [build-dependencies]
 rustversion = { workspace = true }

--- a/vergen-gix/Cargo.toml
+++ b/vergen-gix/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.96.0"
 name = "vergen-gix"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "10.0.1"
+version = "10.0.2"
 
 [package.metadata.cargo-matrix]
 [[package.metadata.cargo-matrix.channel]]
@@ -73,8 +73,8 @@ gix = { workspace = true, features = [
     "sha1",
 ] }
 time = { workspace = true }
-vergen = { version = "10.0.1", path = "../vergen", default-features = false }
-vergen-lib = { version = "10.0.1", path = "../vergen-lib", features = [
+vergen = { version = "10.0.2", path = "../vergen", default-features = false }
+vergen-lib = { version = "10.0.2", path = "../vergen-lib", features = [
     "git",
 ] }
 

--- a/vergen-lib/Cargo.toml
+++ b/vergen-lib/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.96.0"
 name = "vergen-lib"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "10.0.1"
+version = "10.0.2"
 
 [package.metadata.cargo-matrix]
 [[package.metadata.cargo-matrix.channel]]

--- a/vergen-pretty/Cargo.toml
+++ b/vergen-pretty/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.96.0"
 name = "vergen-pretty"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "10.0.1"
+version = "10.0.2"
 
 [package.metadata.cargo-matrix]
 [[package.metadata.cargo-matrix.channel]]
@@ -45,11 +45,11 @@ __vergen_empty_test = ["vergen-gix", "vergen-gix/unstable"]
 [dependencies]
 anyhow = { workspace = true }
 bon = { workspace = true }
-console = { version = "0.16.3", optional = true }
+console = { version = "0.16.4", optional = true }
 convert_case = "0.11.0"
 rand = { workspace = true, optional = true }
-serde = { version = "1.0.228", features = ["derive"], optional = true }
-rkyv = { version = "0.8.16", features = ["std"], optional = true }
+serde = { version = "1.0.229", features = ["derive"], optional = true }
+rkyv = { version = "0.8.17", features = ["std"], optional = true }
 tracing = { version = "0.1.44", features = [
     "max_level_trace",
     "release_max_level_trace",
@@ -58,7 +58,7 @@ tracing = { version = "0.1.44", features = [
 [build-dependencies]
 anyhow = { workspace = true }
 rustversion = { workspace = true }
-vergen-gix = { version = "10.0.1", path = "../vergen-gix", features = [
+vergen-gix = { version = "10.0.2", path = "../vergen-gix", features = [
     "build",
     "cargo",
     "rustc",
@@ -67,7 +67,7 @@ vergen-gix = { version = "10.0.1", path = "../vergen-gix", features = [
 
 [dev-dependencies]
 regex = { workspace = true }
-serde_json = "1.0.150"
+serde_json = "1.0.151"
 tracing-subscriber = { version = "0.3.23", features = ["fmt"] }
 
 [package.metadata.docs.rs]

--- a/vergen/Cargo.toml
+++ b/vergen/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.96.0"
 name = "vergen"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "10.0.1"
+version = "10.0.2"
 
 [package.metadata.cargo-matrix]
 [[package.metadata.cargo-matrix.channel]]
@@ -39,9 +39,9 @@ bon = { workspace = true }
 cargo_metadata = { version = "0.23.1", optional = true }
 regex = { workspace = true, optional = true }
 rustc_version = { version = "0.4.1", optional = true }
-sysinfo = { version = "0.39.5", optional = true }
+sysinfo = { version = "0.39.6", optional = true }
 time = { workspace = true, optional = true }
-vergen-lib = { version = "10.0.1", path = "../vergen-lib" }
+vergen-lib = { version = "10.0.2", path = "../vergen-lib" }
 
 [build-dependencies]
 rustversion = { workspace = true }


### PR DESCRIPTION
## Summary
- Bump workspace dependency versions (anyhow, gix, rand, regex, rustversion, serde_json, serial_test, time) across all crates
- Make the Rakefile `clean` target's `lcov.info` removal exit-code safe on Windows