### PR TITLE
v10.0.3 enhancements

### DIFF
--- a/test_util/Cargo.toml
+++ b/test_util/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.96.0"
 name = "test_util"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "10.0.2"
+version = "10.0.3"
 
 [package.metadata.cargo-matrix]
 [[package.metadata.cargo-matrix.channel]]

--- a/test_util/src/lib.rs
+++ b/test_util/src/lib.rs
@@ -158,7 +158,6 @@ the [`TestRepos`] struct to creat temporary git repositories useful for `vergen-
         mixed_script_confusables,
         named_arguments_used_positionally,
         never_type_fallback_flowing_into_unsafe,
-        no_mangle_generic_items,
         non_ascii_idents,
         non_camel_case_types,
         non_contiguous_range_endpoints,

--- a/vergen-git2/Cargo.toml
+++ b/vergen-git2/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.96.0"
 name = "vergen-git2"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "10.0.2"
+version = "10.0.3"
 
 [package.metadata.cargo-matrix]
 [[package.metadata.cargo-matrix.channel]]
@@ -57,8 +57,8 @@ anyhow = { workspace = true }
 bon = { workspace = true }
 git2-rs = { version = "0.21.0", package = "git2", default-features = false }
 time = { workspace = true }
-vergen = { version = "10.0.2", path = "../vergen", default-features = false }
-vergen-lib = { version = "10.0.2", path = "../vergen-lib", features = [
+vergen = { version = "10.0.3", path = "../vergen", default-features = false }
+vergen-lib = { version = "10.0.3", path = "../vergen-lib", features = [
     "git",
 ] }
 

--- a/vergen-git2/src/lib.rs
+++ b/vergen-git2/src/lib.rs
@@ -334,7 +334,6 @@ let build = Build::builder().build_timestamp(true).build();"
         mixed_script_confusables,
         named_arguments_used_positionally,
         never_type_fallback_flowing_into_unsafe,
-        no_mangle_generic_items,
         non_ascii_idents,
         non_camel_case_types,
         non_contiguous_range_endpoints,

--- a/vergen-gitcl/Cargo.toml
+++ b/vergen-gitcl/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.96.0"
 name = "vergen-gitcl"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "10.0.2"
+version = "10.0.3"
 
 [package.metadata.cargo-matrix]
 [[package.metadata.cargo-matrix.channel]]
@@ -54,8 +54,8 @@ vcs_info = ["vergen-lib/vcs_info"]
 anyhow = { workspace = true }
 bon = { workspace = true }
 time = { workspace = true }
-vergen = { version = "10.0.2", path = "../vergen", default-features = false }
-vergen-lib = { version = "10.0.2", path = "../vergen-lib", features = ["git"] }
+vergen = { version = "10.0.3", path = "../vergen", default-features = false }
+vergen-lib = { version = "10.0.3", path = "../vergen-lib", features = ["git"] }
 
 [build-dependencies]
 rustversion = { workspace = true }

--- a/vergen-gitcl/src/lib.rs
+++ b/vergen-gitcl/src/lib.rs
@@ -334,7 +334,6 @@ let build = Build::builder().build_timestamp(true).build();"
         mixed_script_confusables,
         named_arguments_used_positionally,
         never_type_fallback_flowing_into_unsafe,
-        no_mangle_generic_items,
         non_ascii_idents,
         non_camel_case_types,
         non_contiguous_range_endpoints,

--- a/vergen-gix/Cargo.toml
+++ b/vergen-gix/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.96.0"
 name = "vergen-gix"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "10.0.2"
+version = "10.0.3"
 
 [package.metadata.cargo-matrix]
 [[package.metadata.cargo-matrix.channel]]
@@ -73,8 +73,8 @@ gix = { workspace = true, features = [
     "sha1",
 ] }
 time = { workspace = true }
-vergen = { version = "10.0.2", path = "../vergen", default-features = false }
-vergen-lib = { version = "10.0.2", path = "../vergen-lib", features = [
+vergen = { version = "10.0.3", path = "../vergen", default-features = false }
+vergen-lib = { version = "10.0.3", path = "../vergen-lib", features = [
     "git",
 ] }
 

--- a/vergen-gix/src/lib.rs
+++ b/vergen-gix/src/lib.rs
@@ -334,7 +334,6 @@ let build = Build::builder().build_timestamp(true).build();"
         mixed_script_confusables,
         named_arguments_used_positionally,
         never_type_fallback_flowing_into_unsafe,
-        no_mangle_generic_items,
         non_ascii_idents,
         non_camel_case_types,
         non_contiguous_range_endpoints,

--- a/vergen-lib/Cargo.toml
+++ b/vergen-lib/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.96.0"
 name = "vergen-lib"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "10.0.2"
+version = "10.0.3"
 
 [package.metadata.cargo-matrix]
 [[package.metadata.cargo-matrix.channel]]

--- a/vergen-lib/src/lib.rs
+++ b/vergen-lib/src/lib.rs
@@ -100,7 +100,6 @@
         mixed_script_confusables,
         named_arguments_used_positionally,
         never_type_fallback_flowing_into_unsafe,
-        no_mangle_generic_items,
         non_ascii_idents,
         non_camel_case_types,
         non_contiguous_range_endpoints,

--- a/vergen-pretty/Cargo.toml
+++ b/vergen-pretty/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.96.0"
 name = "vergen-pretty"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "10.0.2"
+version = "10.0.3"
 
 [package.metadata.cargo-matrix]
 [[package.metadata.cargo-matrix.channel]]
@@ -58,7 +58,7 @@ tracing = { version = "0.1.44", features = [
 [build-dependencies]
 anyhow = { workspace = true }
 rustversion = { workspace = true }
-vergen-gix = { version = "10.0.2", path = "../vergen-gix", features = [
+vergen-gix = { version = "10.0.3", path = "../vergen-gix", features = [
     "build",
     "cargo",
     "rustc",

--- a/vergen-pretty/src/lib.rs
+++ b/vergen-pretty/src/lib.rs
@@ -191,7 +191,6 @@ assert!(!buf.is_empty());
         mixed_script_confusables,
         named_arguments_used_positionally,
         never_type_fallback_flowing_into_unsafe,
-        no_mangle_generic_items,
         non_ascii_idents,
         non_camel_case_types,
         non_contiguous_range_endpoints,

--- a/vergen/Cargo.toml
+++ b/vergen/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.96.0"
 name = "vergen"
 readme = "README.md"
 repository = "https://github.com/rustyhorde/vergen"
-version = "10.0.2"
+version = "10.0.3"
 
 [package.metadata.cargo-matrix]
 [[package.metadata.cargo-matrix.channel]]
@@ -41,7 +41,7 @@ regex = { workspace = true, optional = true }
 rustc_version = { version = "0.4.1", optional = true }
 sysinfo = { version = "0.39.6", optional = true }
 time = { workspace = true, optional = true }
-vergen-lib = { version = "10.0.2", path = "../vergen-lib" }
+vergen-lib = { version = "10.0.3", path = "../vergen-lib" }
 
 [build-dependencies]
 rustversion = { workspace = true }

--- a/vergen/src/lib.rs
+++ b/vergen/src/lib.rs
@@ -380,7 +380,6 @@ let build = Build::builder().build_timestamp(true).build();"
         mixed_script_confusables,
         named_arguments_used_positionally,
         never_type_fallback_flowing_into_unsafe,
-        no_mangle_generic_items,
         non_ascii_idents,
         non_camel_case_types,
         non_contiguous_range_endpoints,


### PR DESCRIPTION
## Summary
- Version bump for the next release (v10.0.3)
- Fix nightly clippy: `no_mangle_generic_items` was converted into a hard error and removed as an allow/deny-able lint upstream; drop the stale entry from the shared lint list in every crate

## Test plan
- `scripts/run_clippy.fish` passes clean across all feature combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)