### PR TITLE
fix(clippy): resolve new clippy::assert_is_empty pedantic lint

### DIFF
--- a/vergen-git2/src/git2/mod.rs
+++ b/vergen-git2/src/git2/mod.rs
@@ -1059,7 +1059,7 @@ mod test {
         let git2 = Git2::all_git();
         let mut buf = vec![];
         write!(buf, "{git2:?}")?;
-        assert!(!buf.is_empty());
+        assert_ne!(buf.len(), 0);
         Ok(())
     }
 

--- a/vergen-gitcl/src/gitcl/mod.rs
+++ b/vergen-gitcl/src/gitcl/mod.rs
@@ -1231,7 +1231,7 @@ mod test {
         let gitcl = Gitcl::all_git();
         let mut buf = vec![];
         write!(buf, "{gitcl:?}")?;
-        assert!(!buf.is_empty());
+        assert_ne!(buf.len(), 0);
         Ok(())
     }
 

--- a/vergen-gix/src/gix/mod.rs
+++ b/vergen-gix/src/gix/mod.rs
@@ -954,7 +954,7 @@ mod test {
         let gix = Gix::all_git();
         let mut buf = vec![];
         write!(buf, "{gix:?}")?;
-        assert!(!buf.is_empty());
+        assert_ne!(buf.len(), 0);
         Ok(())
     }
 

--- a/vergen-lib/src/emitter.rs
+++ b/vergen-lib/src/emitter.rs
@@ -530,7 +530,7 @@ pub(crate) mod test {
         let emitter = Emitter::default();
         let mut buf = vec![];
         write!(buf, "{emitter:?}")?;
-        assert!(!buf.is_empty());
+        assert_ne!(buf.len(), 0);
         Ok(())
     }
 
@@ -539,7 +539,7 @@ pub(crate) mod test {
     fn default_is_no_emit() -> Result<()> {
         let mut stdout_buf = vec![];
         _ = Emitter::new().emit_to(&mut stdout_buf)?;
-        assert!(stdout_buf.is_empty());
+        assert_eq!(stdout_buf.len(), 0);
         Ok(())
     }
 

--- a/vergen-lib/src/entries.rs
+++ b/vergen-lib/src/entries.rs
@@ -242,7 +242,7 @@ mod test {
         let config = DefaultConfig::new(true, true, anyhow!("blah"));
         let mut buf = vec![];
         write!(buf, "{config:?}")?;
-        assert!(!buf.is_empty());
+        assert_ne!(buf.len(), 0);
         Ok(())
     }
 }

--- a/vergen-lib/src/keys.rs
+++ b/vergen-lib/src/keys.rs
@@ -272,7 +272,7 @@ mod test {
 
     #[test]
     fn empty_name() {
-        assert!(VergenKey::Empty.name().is_empty());
+        assert_eq!(VergenKey::Empty.name().len(), 0);
     }
 
     #[test]
@@ -288,7 +288,7 @@ mod test {
         let key = VergenKey::Empty;
         let mut buf = vec![];
         write!(buf, "{key:?}")?;
-        assert!(!buf.is_empty());
+        assert_ne!(buf.len(), 0);
         Ok(())
     }
 
@@ -342,7 +342,7 @@ mod test {
         let key = VergenKey::BuildDate;
         let mut buf = vec![];
         write!(buf, "{key:?}")?;
-        assert!(!buf.is_empty());
+        assert_ne!(buf.len(), 0);
         Ok(())
     }
 

--- a/vergen-pretty/src/header/mod.rs
+++ b/vergen-pretty/src/header/mod.rs
@@ -51,7 +51,7 @@ pub type Env = BTreeMap<&'static str, Option<&'static str>>;
 ///     .suffix("HEADER_SUFFIX")
 ///     .build();
 /// assert!(header(&config, Some(&mut buf)).is_ok());
-/// assert!(!buf.is_empty());
+/// assert_ne!(buf.len(), 0);
 /// #     Ok(())
 /// # }
 /// ```
@@ -90,7 +90,7 @@ pub struct Config {
 ///     .suffix("HEADER_SUFFIX")
 ///     .build();
 /// assert!(header(&config, Some(&mut buf)).is_ok());
-/// assert!(!buf.is_empty());
+/// assert_ne!(buf.len(), 0);
 /// #     Ok(())
 /// # }
 /// ```
@@ -284,7 +284,7 @@ mod test {
         let config = Config::default();
         let mut buf = vec![];
         write!(buf, "{config:?}")?;
-        assert!(!buf.is_empty());
+        assert_ne!(buf.len(), 0);
         Ok(())
     }
 
@@ -310,7 +310,7 @@ mod test {
         let mut buf = vec![];
         let config = Config::builder().env(vergen_pretty_env!()).build();
         assert!(header(&config, Some(&mut buf)).is_ok());
-        assert!(!buf.is_empty());
+        assert_ne!(buf.len(), 0);
         let header_str = String::from_utf8_lossy(&buf);
         assert!(BUILD_TIMESTAMP.is_match(&header_str));
         assert!(BUILD_SEMVER.is_match(&header_str));
@@ -326,7 +326,7 @@ mod test {
         let buf: Vec<u8> = vec![];
         let config = Config::builder().env(vergen_pretty_env!()).build();
         assert!(header(&config, None::<&mut Vec<u8>>).is_ok());
-        assert!(buf.is_empty());
+        assert_eq!(buf.len(), 0);
     }
 
     #[test]
@@ -342,7 +342,7 @@ mod test {
             .suffix(HEADER_SUFFIX)
             .build();
         assert!(header(&config, Some(&mut buf)).is_ok());
-        assert!(!buf.is_empty());
+        assert_ne!(buf.len(), 0);
         let header_str = String::from_utf8_lossy(&buf);
         assert!(BUILD_TIMESTAMP.is_match(&header_str));
         assert!(BUILD_SEMVER.is_match(&header_str));
@@ -363,7 +363,7 @@ mod test {
             .suffix(HEADER_SUFFIX)
             .build();
         assert!(header(&config, Some(&mut buf)).is_ok());
-        assert!(!buf.is_empty());
+        assert_ne!(buf.len(), 0);
         let header_str = String::from_utf8_lossy(&buf);
         assert!(BUILD_TIMESTAMP.is_match(&header_str));
         assert!(BUILD_SEMVER.is_match(&header_str));
@@ -384,7 +384,7 @@ mod test {
             .suffix(HEADER_SUFFIX)
             .build();
         assert!(header(&config, Some(&mut buf)).is_ok());
-        assert!(!buf.is_empty());
+        assert_ne!(buf.len(), 0);
         let header_str = String::from_utf8_lossy(&buf);
         assert!(BUILD_TIMESTAMP.is_match(&header_str));
         assert!(BUILD_SEMVER.is_match(&header_str));
@@ -404,7 +404,7 @@ mod test {
             .env(vergen_pretty_env!())
             .build();
         assert!(header(&config, Some(&mut buf)).is_ok());
-        assert!(!buf.is_empty());
+        assert_ne!(buf.len(), 0);
         let header_str = String::from_utf8_lossy(&buf);
         assert!(BUILD_TIMESTAMP.is_match(&header_str));
         assert!(BUILD_SEMVER.is_match(&header_str));
@@ -424,7 +424,7 @@ mod test {
             .env(vergen_pretty_env!())
             .build();
         assert!(header(&config, Some(&mut buf)).is_ok());
-        assert!(!buf.is_empty());
+        assert_ne!(buf.len(), 0);
         let header_str = String::from_utf8_lossy(&buf);
         assert!(BUILD_TIMESTAMP.is_match(&header_str));
         assert!(BUILD_SEMVER.is_match(&header_str));

--- a/vergen-pretty/src/lib.rs
+++ b/vergen-pretty/src/lib.rs
@@ -40,9 +40,9 @@
 //!     .build()
 //!     .display(&mut stdout)?;
 //! # if empty {
-//! #    assert!(stdout.is_empty());
+//! #    assert_eq!(stdout.len(), 0);
 //! # } else {
-//! assert!(!stdout.is_empty());
+//! assert_ne!(stdout.len(), 0);
 //! # }
 //! #     Ok(())
 //! # }
@@ -81,7 +81,7 @@ let config = Config::builder()"
     .suffix("HEADER_SUFFIX")
     .build();
 assert!(header(&config, Some(&mut buf)).is_ok());
-assert!(!buf.is_empty());
+assert_ne!(buf.len(), 0);
 #     Ok(())
 # }
 ```

--- a/vergen-pretty/src/pretty/feature/color.rs
+++ b/vergen-pretty/src/pretty/feature/color.rs
@@ -87,9 +87,9 @@ mod test {
         let fmt = Pretty::builder().env(map).key_style(red_bold).build();
         fmt.display(&mut stdout)?;
         if empty {
-            assert!(stdout.is_empty());
+            assert_eq!(stdout.len(), 0);
         } else {
-            assert!(!stdout.is_empty());
+            assert_ne!(stdout.len(), 0);
         }
         Ok(())
     }
@@ -103,9 +103,9 @@ mod test {
         let fmt = Pretty::builder().env(map).value_style(red_bold).build();
         fmt.display(&mut stdout)?;
         if empty {
-            assert!(stdout.is_empty());
+            assert_eq!(stdout.len(), 0);
         } else {
-            assert!(!stdout.is_empty());
+            assert_ne!(stdout.len(), 0);
         }
         Ok(())
     }
@@ -121,7 +121,7 @@ mod test {
             .build();
         let fmt = Pretty::builder().env(map).prefix(prefix).build();
         fmt.display(&mut stdout)?;
-        assert!(!stdout.is_empty());
+        assert_ne!(stdout.len(), 0);
         Ok(())
     }
 
@@ -136,7 +136,7 @@ mod test {
             .build();
         let fmt = Pretty::builder().env(map).suffix(suffix).build();
         fmt.display(&mut stdout)?;
-        assert!(!stdout.is_empty());
+        assert_ne!(stdout.len(), 0);
         Ok(())
     }
 }

--- a/vergen-pretty/src/pretty/mod.rs
+++ b/vergen-pretty/src/pretty/mod.rs
@@ -252,7 +252,7 @@ mod tests {
         let pretty = Pretty::builder().env(map).build();
         let mut buf = vec![];
         write!(buf, "{pretty:?}")?;
-        assert!(!buf.is_empty());
+        assert_ne!(buf.len(), 0);
         Ok(())
     }
 
@@ -264,9 +264,9 @@ mod tests {
         let fmt = Pretty::builder().env(map).build();
         fmt.display(&mut stdout)?;
         if empty {
-            assert!(stdout.is_empty());
+            assert_eq!(stdout.len(), 0);
         } else {
-            assert!(!stdout.is_empty());
+            assert_ne!(stdout.len(), 0);
         }
         Ok(())
     }
@@ -279,9 +279,9 @@ mod tests {
         let fmt = Pretty::builder().env(map).category(false).build();
         fmt.display(&mut stdout)?;
         if empty {
-            assert!(stdout.is_empty());
+            assert_eq!(stdout.len(), 0);
         } else {
-            assert!(!stdout.is_empty());
+            assert_ne!(stdout.len(), 0);
         }
         Ok(())
     }
@@ -294,9 +294,9 @@ mod tests {
         let fmt = Pretty::builder().env(map).build();
         fmt.display(&mut stdout)?;
         if empty {
-            assert!(stdout.is_empty());
+            assert_eq!(stdout.len(), 0);
         } else {
-            assert!(!stdout.is_empty());
+            assert_ne!(stdout.len(), 0);
         }
         Ok(())
     }

--- a/vergen-pretty/src/pretty/prefix.rs
+++ b/vergen-pretty/src/pretty/prefix.rs
@@ -97,7 +97,7 @@ mod test {
             .build();
         let mut buf = vec![];
         write!(buf, "{prefix:?}")?;
-        assert!(!buf.is_empty());
+        assert_ne!(buf.len(), 0);
         Ok(())
     }
 
@@ -110,7 +110,7 @@ mod test {
             .build();
         let fmt = Pretty::builder().env(map).prefix(prefix).build();
         fmt.display(&mut stdout)?;
-        assert!(!stdout.is_empty());
+        assert_ne!(stdout.len(), 0);
         Ok(())
     }
 }

--- a/vergen-pretty/src/pretty/suffix.rs
+++ b/vergen-pretty/src/pretty/suffix.rs
@@ -95,7 +95,7 @@ mod test {
             .build();
         let mut buf = vec![];
         write!(buf, "{suffix:?}")?;
-        assert!(!buf.is_empty());
+        assert_ne!(buf.len(), 0);
         Ok(())
     }
 
@@ -108,7 +108,7 @@ mod test {
             .build();
         let fmt = Pretty::builder().env(map).suffix(suffix).build();
         fmt.display(&mut stdout)?;
-        assert!(!stdout.is_empty());
+        assert_ne!(stdout.len(), 0);
         Ok(())
     }
 }

--- a/vergen/src/feature/build.rs
+++ b/vergen/src/feature/build.rs
@@ -391,7 +391,7 @@ mod test {
         let build = Build::all_build();
         let mut buf = vec![];
         write!(buf, "{build:?}")?;
-        assert!(!buf.is_empty());
+        assert_ne!(buf.len(), 0);
         Ok(())
     }
 

--- a/vergen/src/feature/cargo.rs
+++ b/vergen/src/feature/cargo.rs
@@ -522,7 +522,7 @@ mod test {
         let cargo = Cargo::all_cargo();
         let mut buf = vec![];
         write!(buf, "{cargo:?}")?;
-        assert!(!buf.is_empty());
+        assert_ne!(buf.len(), 0);
         Ok(())
     }
 

--- a/vergen/src/feature/rustc.rs
+++ b/vergen/src/feature/rustc.rs
@@ -410,7 +410,7 @@ mod test {
         let rustc = Rustc::all_rustc();
         let mut buf = vec![];
         write!(buf, "{rustc:?}")?;
-        assert!(!buf.is_empty());
+        assert_ne!(buf.len(), 0);
         Ok(())
     }
 

--- a/vergen/src/feature/si.rs
+++ b/vergen/src/feature/si.rs
@@ -609,7 +609,7 @@ mod test {
         let si = Sysinfo::all_sysinfo();
         let mut buf = vec![];
         write!(buf, "{si:?}")?;
-        assert!(!buf.is_empty());
+        assert_ne!(buf.len(), 0);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Nightly clippy now flags `assert!(x.is_empty())` / `assert!(!x.is_empty())` under `clippy::assert_is_empty` (part of `clippy::pedantic`, which is `deny`d in every crate's `lib.rs`). This broke `rake clippy` / `cargo matrix -c nightly clippy`.

## Changes

- Rewrote these patterns across `vergen`, `vergen-lib`, `vergen-pretty`, `vergen-gitcl`, `vergen-git2`, and `vergen-gix` test code (plus a couple of doc examples) as `assert_eq!`/`assert_ne!` comparisons on `.len()`.
- Clippy's own suggested fix (`assert_ne!(buf, [] as [u8; 0])`) was avoided because it trips this repo's separate `trivial_casts` deny lint — the `.len()` form satisfies both.

## Testing

- `rake clippy` passes clean across the full nightly feature matrix.
- `cargo test -p vergen-pretty --doc -F header,color` passes (verifies the doc-comment edits still compile/run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)